### PR TITLE
Fix how the regex string is obtained in exitPropTestRegex().

### DIFF
--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -1577,7 +1577,7 @@ class MatchListener(STIXPatternListener):
 
         obs_values = self.__pop(debug_label)
 
-        regex = regex_terminal.getText()[1:-1]  # strip "quotes"
+        regex = _literal_terminal_to_python_val(regex_terminal)
         compiled_re = re.compile(regex)
 
         def regex_pred(value):


### PR DESCRIPTION
It needs to go through _literal_terminal_to_python_val(), because changing it to a string literal opens up all the string literal escaping possibilities, which need to be handled.  The old regex literal didn't have to worry about that.  Handling escaping is the job of the coercers.

Speaking of which, string literal escaping style in the matcher is no longer spec-compliant.  But it should just need a fix in the coercer, and all users of string literals should get the updated handling for free, provided they're using the aforementioned function.
