### PR TITLE
Changed invalid whitespace escape sequence '\v' to '\u000B'

### DIFF
--- a/stix2matcher/grammars/STIXPattern.g4
+++ b/stix2matcher/grammars/STIXPattern.g4
@@ -230,7 +230,7 @@ fragment Base64Char: [A-Za-z0-9+/=];
 
 // Whitespace and comments
 //
-WS  :  [ \t\v\r\n\u000C\u0085\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000]+ -> skip
+WS  :  [ \t\r\n\u000B\u000C\u0085\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000]+ -> skip
     ;
 
 COMMENT


### PR DESCRIPTION
I tried running the tests with a parser generated with the recently-released ANTLR 4.6.  I was curious to see if there would be any compatibility problems.  I did find one problem, which was that it errored out due to invalid escape sequence '\v' [1].  I suspect this was also invalid in earlier versions of ANTLR, but was silently ignored.  I've been seeing that squiggly red underline in my IDE for a long time.

My guess is that it was intended to represent a vertical tab character.  I found a vertical tab character in the unicode standard as U+000B, so I switched to that instead.

1. https://github.com/antlr/antlr4/blob/master/doc/lexer-rules.md#lexer-rule-elements
