### PR TITLE
Encoding-related fixes

### DIFF
--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -884,10 +884,11 @@ class MatchListener(STIXPatternListener):
 
         if self.__verbose:
             if label:
-                label = label.encode("unicode_escape")
+                label = label.encode("unicode_escape").decode("ascii")
                 print(u"{}: ".format(label), end=u"")
-            # pprint seems to unicode-escape things automatically.
-            print(u"push {}".format(pprint.pformat(val)))
+            print(u"push {}".format(pprint.pformat(val).
+                                    encode("unicode_escape").
+                                    decode("ascii")))
 
     def __pop(self, label=None):
         """Utility for popping a value off the compute stack.
@@ -898,10 +899,11 @@ class MatchListener(STIXPatternListener):
 
         if self.__verbose:
             if label:
-                label = label.encode("unicode_escape")
+                label = label.encode("unicode_escape").decode("ascii")
                 print(u"{}: ".format(label), end=u"")
-            # pprint seems to unicode-escape things automatically.
-            print(u"pop {}".format(pprint.pformat(val)))
+            print(u"pop {}".format(pprint.pformat(val).
+                                   encode("unicode_escape").
+                                   decode("ascii")))
 
         return val
 
@@ -2014,7 +2016,7 @@ def main():
                 continue  # skip blank lines
             if pattern[0] == u"#":
                 continue  # skip commented out lines
-            escaped_pattern = pattern.encode("unicode_escape")
+            escaped_pattern = pattern.encode("unicode_escape").decode("ascii")
             if match(pattern, containers, timestamps, args.verbose):
                 print(u"\nPASS: ", escaped_pattern)
             else:


### PR DESCRIPTION
The file-related I/O code for commandline functionality, was messy.  The text files needed to be opened in a textual mode with a proper encoding, but python2's argparse.FileType doesn't support that.  And even if it did, using it wouldn't allow the encoding to be settable via another commandline parameter.  So I ditched argparse.FileType and switched to normal string params, opened manually via io.open() (python2's plain open() function also doesn't support setting an encoding).

Also, I thought I had the logging working with unicode characters, but I found it was still crashing when attempting to print funny characters to the console, using a codec that didn't support those characters.  So decided to run all values through the "unicode_escape" codec to ensure everything is printable.  And to avoid the ugly b"..." syntax (under python3, that codec yields binary values), it's subsequently decoded back to a string, as ascii.