### PR TITLE
Fixed bugs related to 'None' bindings.

### DIFF
--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -1181,7 +1181,8 @@ class MatchListener(STIXPatternListener):
         filtered_bindings = []
         for binding in bindings:
             if _timestamps_within(
-                    (self.__timestamps[obs_id] for obs_id in binding),
+                    (self.__timestamps[obs_id] for obs_id in binding
+                     if obs_id is not None),
                     duration):
                 filtered_bindings.append(binding)
 
@@ -1206,7 +1207,7 @@ class MatchListener(STIXPatternListener):
         for binding in bindings:
             in_bounds = all(
                 start_time <= self.__timestamps[obs_id] < stop_time
-                for obs_id in binding
+                for obs_id in binding if obs_id is not None
             )
 
             if in_bounds:


### PR DESCRIPTION
Errors occurred when using temporal qualifiers (WITHIN, START/STOP) with bindings which contained 'None'.  It is a simple fix, I'd simply forgotten to update the code in a couple places.

There should be additional test cases to cover this, but I'm planning on adding them with a separate pull request.  I stumbled across this bug when making a separate change, which I thought made more sense as a separate PR.