### PR TITLE
Added unicode NFC normalization to LIKE and MATCHES operators

### DIFF
--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -16,6 +16,7 @@ import six
 import socket
 import struct
 import sys
+import unicodedata
 
 import antlr4
 import antlr4.error.Errors
@@ -1530,6 +1531,7 @@ class MatchListener(STIXPatternListener):
 
         obs_values = self.__pop(debug_label)
 
+        operand_str = unicodedata.normalize("NFC", operand_str)
         regex = _like_to_regex(operand_str)
         # compile and cache this to improve performance
         compiled_re = re.compile(regex)
@@ -1539,6 +1541,7 @@ class MatchListener(STIXPatternListener):
             if not isinstance(value, six.text_type):
                 return False
 
+            value = unicodedata.normalize("NFC", value)
             result = compiled_re.match(value)
             if ctx.NOT():
                 result = not result
@@ -1572,6 +1575,7 @@ class MatchListener(STIXPatternListener):
         obs_values = self.__pop(debug_label)
 
         regex = _literal_terminal_to_python_val(regex_terminal)
+        regex = unicodedata.normalize("NFC", regex)
         compiled_re = re.compile(regex)
 
         def regex_pred(value):
@@ -1579,6 +1583,7 @@ class MatchListener(STIXPatternListener):
                 return False
 
             # Don't need a full-string match
+            value = unicodedata.normalize("NFC", value)
             result = compiled_re.search(value)
             if ctx.NOT():
                 result = not result

--- a/stix2matcher/test/test_unicode_normalization.py
+++ b/stix2matcher/test/test_unicode_normalization.py
@@ -1,0 +1,116 @@
+import datetime
+import dateutil.tz
+import pytest
+
+from stix2matcher.matcher import match
+
+_observations = [
+    {
+        "type": "cybox-container",
+        "objects": {
+            "0": {
+                "type": "test",
+                "ddots": {
+                    # Three different ways of representing "d" with dot above
+                    # and below.
+                    "nfc": u"\u1e0d\u0307",
+                    "nfd": u"d\u0323\u0307",
+                    "alt1": u"\u1e0b\u0323"
+                }
+            }
+        }
+    }
+]
+
+_timestamps = [datetime.datetime.now(dateutil.tz.tzutc())] * len(_observations)
+
+
+def _all_kv_pairs():
+    """
+    This combines the prop names and values in all different combinations.
+    """
+    for k in _observations[0]["objects"]["0"]["ddots"]:
+        for v in _observations[0]["objects"]["0"]["ddots"].values():
+            yield k, v
+
+
+def _matched_kv_pairs():
+    """
+    This returns an iterable through all the matched prop name/value pairs.
+    """
+    return _observations[0]["objects"]["0"]["ddots"].items()
+
+
+def _mismatched_kv_pairs():
+    """
+    This combines the prop names and values in all different combinations,
+    except for the matching pairs.
+    """
+    for i, k in enumerate(_observations[0]["objects"]["0"]["ddots"]):
+        for j, v in enumerate(_observations[0]["objects"]["0"]["ddots"].values()):
+            if i != j:
+                yield k, v
+
+
+@pytest.mark.parametrize("pattern", [
+    u"[test:ddots.{} like '{}']".format(k, v)
+    for k, v in _all_kv_pairs()
+])
+def test_unicode_normalization_like_match(pattern):
+    assert match(pattern, _observations, _timestamps)
+
+
+@pytest.mark.parametrize("pattern", [
+    u"[test:ddots.{} matches '^{}$']".format(k, v)
+    for k, v in _all_kv_pairs()
+])
+def test_unicode_normalization_regex_match(pattern):
+    assert match(pattern, _observations, _timestamps)
+
+
+@pytest.mark.parametrize("pattern", [
+    u"[test:ddots.{} != '{}']".format(k, v)
+    for k, v in _mismatched_kv_pairs()
+])
+def test_unicode_normalization_ne_match(pattern):
+    assert match(pattern, _observations, _timestamps)
+
+
+@pytest.mark.parametrize("pattern", [
+    u"[test:ddots.{} != '{}']".format(k, v)
+    for k, v in _matched_kv_pairs()
+])
+def test_unicode_normalization_ne_nomatch(pattern):
+    assert not match(pattern, _observations, _timestamps)
+
+
+@pytest.mark.parametrize("pattern", [
+    u"[test:ddots.{} = '{}']".format(k, v)
+    for k, v in _matched_kv_pairs()
+])
+def test_unicode_normalization_eq_match(pattern):
+    assert match(pattern, _observations, _timestamps)
+
+
+@pytest.mark.parametrize("pattern", [
+    u"[test:ddots.{} = '{}']".format(k, v)
+    for k, v in _mismatched_kv_pairs()
+])
+def test_unicode_normalization_eq_nomatch(pattern):
+    assert not match(pattern, _observations, _timestamps)
+
+
+@pytest.mark.parametrize("pattern", [
+    u"[test:ddots.{} in ('{}')]".format(k, v)
+    for k, v in _matched_kv_pairs()
+])
+def test_unicode_normalization_set_match(pattern):
+    assert match(pattern, _observations, _timestamps)
+
+
+@pytest.mark.parametrize("pattern", [
+    u"[test:ddots.{} in ('{}')]".format(k, v)
+    for k, v in _mismatched_kv_pairs()
+])
+def test_unicode_normalization_set_nomatch(pattern):
+    assert not match(pattern, _observations, _timestamps)


### PR DESCRIPTION
Also added unicode normalization tests.

I did not do NFC normalization for the set 'IN' operator.  I thought it made more sense for that to remain consistent with the behavior of the '=' operator, although the spec implies that normalization should be done in that case too.  (This should probably be verified.)
