### PR TITLE
Bugfixes, adding more tests

### DIFF
--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -1369,9 +1369,10 @@ class MatchListener(STIXPatternListener):
         def equality_pred(value):
 
             # timestamp hackage: if we have a timestamp literal from the
-            # pattern, try to interpret the json value as a timestamp too.
-            if literal_terminal.getSymbol().type == \
-                    STIXPatternParser.TimestampLiteral:
+            # pattern and a string from the json, try to interpret the json
+            # value as a timestamp too.
+            if isinstance(literal_value, datetime.datetime) and \
+                    isinstance(value, six.text_type):
                 try:
                     value = _str_to_datetime(value)
                 except ValueError as e:
@@ -1427,9 +1428,10 @@ class MatchListener(STIXPatternListener):
         def order_pred(value):
 
             # timestamp hackage: if we have a timestamp literal from the
-            # pattern, try to interpret the json value as a timestamp too.
-            if literal_terminal.getSymbol().type == \
-                    STIXPatternParser.TimestampLiteral:
+            # pattern and a string from the json, try to interpret the json
+            # value as a timestamp too.
+            if isinstance(literal_value, datetime.datetime) and \
+                    isinstance(value, six.text_type):
                 try:
                     value = _str_to_datetime(value)
                 except ValueError as e:
@@ -1491,7 +1493,24 @@ class MatchListener(STIXPatternListener):
         s = self.__pop(debug_label)  # pop the set
         obs_values = self.__pop(debug_label)  # pop the observation values
 
+        # Only need to check one member; exitSetLiteral() ensures that all
+        # members of the set have the same type.
+        is_set_of_timestamps = s and \
+                               isinstance(next(iter(s)), datetime.datetime)
+
         def set_pred(value):
+            # timestamp hackage: if we have a set of timestamp literals from
+            # the pattern and a string from the json, try to interpret the json
+            # value as a timestamp too.
+            if is_set_of_timestamps and isinstance(value, six.text_type):
+                try:
+                    value = _str_to_datetime(value)
+                except ValueError as e:
+                    six.raise_from(
+                        MatcherException(u"Invalid timestamp in JSON: {}".format(
+                            value
+                        )), e)
+
             result = False
             try:
                 result = value in s
@@ -1877,6 +1896,13 @@ class MatchListener(STIXPatternListener):
             literal_terminal = _get_first_terminal_descendant(literal_node)
             literal_value = _literal_terminal_to_python_val(literal_terminal)
             s.add(literal_value)
+
+        # Check for homogeneity of datatypes in the set
+        if s:
+            type_ = type(next(iter(s)))
+            if not all(type(elt) is type_ for elt in s):
+                raise MatcherException("Nonhomogenous set: {}".format(
+                    ctx.getText()))
 
         self.__push(s, u"exitSetLiteral ({})".format(ctx.getText()))
 

--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -1496,7 +1496,7 @@ class MatchListener(STIXPatternListener):
         # Only need to check one member; exitSetLiteral() ensures that all
         # members of the set have the same type.
         is_set_of_timestamps = s and \
-                               isinstance(next(iter(s)), datetime.datetime)
+            isinstance(next(iter(s)), datetime.datetime)
 
         def set_pred(value):
             # timestamp hackage: if we have a set of timestamp literals from

--- a/stix2matcher/test/test_basic_ops.py
+++ b/stix2matcher/test/test_basic_ops.py
@@ -1,0 +1,259 @@
+import pytest
+
+from stix2matcher.matcher import match, MatcherException
+
+
+_observations = [
+    {
+        "type": "observed-data",
+        "number_observed": 1,
+        "first_observed": "2014-04-19T06:51:26Z",
+        "objects": {
+            "0": {
+                "type": "test",
+                "int": 5,
+                "float": 12.658,
+                "bool": True,
+                "string": u"hello",
+                "ip": u"11.22.33.44",
+                "cidr": u"11.22.33.44/20"
+            }
+        }
+    }
+]
+
+
+@pytest.mark.parametrize("pattern", [
+    "[test:int > 3]",
+    "[test:int < 12]",
+    "[test:int > 4.9]",
+    "[test:int < 5.1]",
+    "[test:int >= 5]",
+    "[test:int <= 5]",
+    "[test:int != false]",
+    "[test:int != true]",
+    "[test:int != 'world']",
+    "[test:int != h'010203']",
+    "[test:int != b'AQIDBA==']",
+    "[test:int != t'1965-07-19T22:41:38Z']",
+    "[test:int in (-4, 5, 6)]",
+    "[test:int not in ('a', 'b', 'c')]"
+])
+def test_basic_ops_int_match(pattern):
+    assert match(pattern, _observations)
+
+
+@pytest.mark.parametrize("pattern", [
+    "[test:int > 8]",
+    "[test:int < 2]",
+    "[test:int > 5.1]",
+    "[test:int < 4.9]",
+    "[test:int = false]",
+    "[test:int = true]",
+    "[test:int = 'world']",
+    "[test:int = h'010203']",
+    "[test:int > h'010203']",
+    "[test:int = b'AQIDBA==']",
+    "[test:int < b'AQIDBA==']",
+    "[test:int = t'1965-07-19T22:41:38Z']",
+    "[test:int > t'1965-07-19T22:41:38Z']",
+    "[test:int like 'he%']",
+    "[test:int not like 'he%']",
+    "[test:int matches 'l+']",
+    "[test:int not matches 'l+']",
+    "[test:int not in (-4, 5, 6)]",
+    "[test:int in ('a', 'b', 'c')]"
+])
+def test_basic_ops_int_nomatch(pattern):
+    assert not match(pattern, _observations)
+
+
+@pytest.mark.parametrize("pattern", [
+    "[test:float > 3]",
+    "[test:float < 22]",
+    "[test:float > 12.65799]",
+    "[test:float < 12.65801]",
+    "[test:float >= 12.658]",
+    "[test:float <= 12.658]",
+    "[test:float != false]",
+    "[test:float != true]",
+    "[test:float != 'world']",
+    "[test:float != h'010203']",
+    "[test:float != b'AQIDBA==']",
+    "[test:float != t'1965-07-19T22:41:38Z']",
+    "[test:float in (-4.21, 12.658, 964.321)]",
+    "[test:float not in ('a', 'b', 'c')]"
+])
+def test_basic_ops_float_match(pattern):
+    assert match(pattern, _observations)
+
+
+@pytest.mark.parametrize("pattern", [
+    "[test:float > 22]",
+    "[test:float < 3]",
+    "[test:float > 12.65801]",
+    "[test:float < 12.65799]",
+    "[test:float = false]",
+    "[test:float = true]",
+    "[test:float = 'world']",
+    "[test:float = h'010203']",
+    "[test:float > h'010203']",
+    "[test:float = b'AQIDBA==']",
+    "[test:float < b'AQIDBA==']",
+    "[test:float = t'1965-07-19T22:41:38Z']",
+    "[test:float > t'1965-07-19T22:41:38Z']",
+    "[test:float like 'he%']",
+    "[test:float not like 'he%']",
+    "[test:float matches 'l+']",
+    "[test:float not matches 'l+']",
+    "[test:float not in (-4.21, 12.658, 964.321)]",
+    "[test:float in ('a', 'b', 'c')]"
+])
+def test_basic_ops_float_nomatch(pattern):
+    assert not match(pattern, _observations)
+
+
+@pytest.mark.parametrize("pattern", [
+    "[test:bool != 1]",
+    "[test:bool != 32.567]",
+    "[test:bool = true]",
+    "[test:bool != false]",
+    "[test:bool != 'world']",
+    "[test:bool != h'010203']",
+    "[test:bool != b'AQIDBA==']",
+    "[test:bool != t'1965-07-19T22:41:38Z']",
+    "[test:bool in (false, true, false)]",
+    "[test:bool not in ('a', 'b', 'c')]"
+])
+def test_basic_ops_bool_match(pattern):
+    assert match(pattern, _observations)
+
+
+@pytest.mark.parametrize("pattern", [
+    "[test:bool = 1]",
+    "[test:bool = 32.567]",
+    "[test:bool != true]",
+    "[test:bool = false]",
+    "[test:bool = 'world']",
+    "[test:bool = h'010203']",
+    "[test:bool = b'AQIDBA==']",
+    "[test:bool = t'1965-07-19T22:41:38Z']",
+    "[test:bool like 'he%']",
+    "[test:bool not like 'he%']",
+    "[test:bool matches 'l+']",
+    "[test:bool not matches 'l+']",
+    "[test:bool not in (false, true, false)]",
+    "[test:bool in ('a', 'b', 'c')]"
+])
+def test_basic_ops_bool_nomatch(pattern):
+    assert not match(pattern, _observations)
+
+
+@pytest.mark.parametrize("pattern", [
+    "[test:string != 1]",
+    "[test:string != 32.567]",
+    "[test:string != true]",
+    "[test:string != false]",
+    "[test:string = 'hello']",
+    "[test:string != 'world']",
+    "[test:string > 'alice']",
+    "[test:string < 'zelda']",
+    "[test:string >= 'hello']",
+    "[test:string <= 'hello']",
+    "[test:string != h'010203']",
+    "[test:string != b'AQIDBA==']",
+    "[test:string like 'he%']",
+    "[test:string like 'he__o']",
+    "[test:string matches 'l+']",
+    "[test:string matches '.lo$']",
+    "[test:string in ('goodbye', 'hello', 'world')]",
+    "[test:string not in (1, 2, 3)]"
+])
+def test_basic_ops_string_match(pattern):
+    assert match(pattern, _observations)
+
+
+@pytest.mark.parametrize("pattern", [
+    "[test:string = 1]",
+    "[test:string = 32.567]",
+    "[test:string = true]",
+    "[test:string = false]",
+    "[test:string != 'hello']",
+    "[test:string = 'world']",
+    "[test:string < 'alice']",
+    "[test:string > 'zelda']",
+    "[test:string <= 'alice']",
+    "[test:string >= 'zelda']",
+    "[test:string = h'010203']",
+    "[test:string = b'AQIDBA==']",
+    "[test:string not like 'he%']",
+    "[test:string not like 'he__o']",
+    "[test:string not matches 'l+']",
+    "[test:string not matches '.lo$']",
+    "[test:string not in ('goodbye', 'hello', 'world')]",
+    "[test:string in (1, 2, 3)]"
+])
+def test_basic_ops_string_nomatch(pattern):
+    assert not match(pattern, _observations)
+
+
+@pytest.mark.parametrize("pattern", [
+    # These are errors because a timestamp literal is used in the pattern,
+    # which causes the matcher to try to interpret the JSON value as a
+    # timestamp as well.  If this merely caused a false (for '=') or true
+    # (for '!=') result, then timestamp formatting errors in the JSON would
+    # silently slip through, causing potential false negatives.  It's
+    # perhaps safer to assume in this situation that a string JSON value was
+    # really intended to be a timestamp, and error out if it's incorrectly
+    # formatted.
+    "[test:string = t'1965-07-19T22:41:38Z']",
+    "[test:string != t'1965-07-19T22:41:38Z']",
+    "[test:string > t'1965-07-19T22:41:38Z']",
+])
+def test_basic_ops_string_err(pattern):
+    with pytest.raises(MatcherException):
+        match(pattern, _observations)
+
+
+@pytest.mark.parametrize("pattern", [
+    "[test:ip issubset '11.22.41.123/20']",
+    "[test:ip not issubset '11.22.123.41/20']",
+    "[test:cidr issuperset '11.22.41.123']",
+    "[test:cidr issuperset '11.22.41.123/29']",
+    "[test:cidr not issuperset '11.22.33.44/13']",
+    "[test:cidr not issuperset '11.22.123.41/29']",
+])
+def test_basic_ops_ip_match(pattern):
+    assert match(pattern, _observations)
+
+
+@pytest.mark.parametrize("pattern", [
+    "[test:ip not issubset '11.22.41.123/20']",
+    "[test:ip issubset '11.22.123.41/20']",
+    "[test:cidr not issuperset '11.22.41.123']",
+    "[test:cidr not issuperset '11.22.41.123/29']",
+    "[test:cidr issuperset '11.22.33.44/13']",
+    "[test:cidr issuperset '11.22.123.41/29']",
+])
+def test_basic_ops_ip_nomatch(pattern):
+    assert not match(pattern, _observations)
+
+
+@pytest.mark.parametrize("pattern", [
+    "[test:string not in ()]"
+])
+def test_basic_ops_emptyset_match(pattern):
+    assert match(pattern, _observations)
+
+
+@pytest.mark.parametrize("pattern", [
+    "[test:string in ()]"
+])
+def test_basic_ops_emptyset_nomatch(pattern):
+    assert not match(pattern, _observations)
+
+
+def test_basic_ops_set_err():
+    # Sets are required to contain elements of a single type.
+    with pytest.raises(MatcherException):
+        match("[test:int in (1, true, 'hello')]", _observations)

--- a/stix2matcher/test/test_null.py
+++ b/stix2matcher/test/test_null.py
@@ -21,7 +21,7 @@ _observations = [
     "[null_test:name > 'alice']",
     "[null_test:name <= 'alice']",
     "[null_test:name = 'alice']",
-    "[null_test:name in ('alice', 12, false)]",
+    "[null_test:name in ('alice', 'bob', 'carol')]",
     "[null_test:name like 'alice']",
     "[null_test:name matches 'alice']",
     "[null_test:name issubset '12.23.32.12/14']",
@@ -40,7 +40,7 @@ def test_notequal_null_json(pattern):
 
 @pytest.mark.parametrize("pattern", [
     "[null_test:name = null]",
-    "[null_test:name in ('alice', null, false)]",
+    "[null_test:name in (null, null, null)]",
     "[null_test:name like null]",
     "[null_test:name matches null]",
     "[null_test:name issubset null]",

--- a/stix2matcher/test/test_timestamps.py
+++ b/stix2matcher/test/test_timestamps.py
@@ -10,15 +10,15 @@ _observations = [
         "objects": {
             "0": {
                 "type": "event",
-                "good_ts": "2010-05-21T13:21:43Z",
-                "good_ts_frac": "2010-05-21T13:21:43.1234Z",
+                "good_ts": u"2010-05-21T13:21:43Z",
+                "good_ts_frac": u"2010-05-21T13:21:43.1234Z",
                 "bad_ts": [
-                    "2010-05-21T13:21:43",
-                    "2010-05-21T13:21:43z",
-                    "2010-05-21t13:21:43Z",
-                    "2010/05/21T13:21:43Z",
-                    "2010-05-21T13:21:99Z",
-                    "2010-05-21T13:21Z"
+                    u"2010-05-21T13:21:43",
+                    u"2010-05-21T13:21:43z",
+                    u"2010-05-21t13:21:43Z",
+                    u"2010/05/21T13:21:43Z",
+                    u"2010-05-21T13:21:99Z",
+                    u"2010-05-21T13:21Z"
                 ]
             }
         }
@@ -31,7 +31,9 @@ _observations = [
     "[event:good_ts != t'1974-11-05T05:31:11Z']",
     "[event:good_ts > t'1974-11-05T05:31:11Z']",
     "[event:good_ts < t'3012-08-17T17:43:55Z']",
-    "[event:good_ts_frac = t'2010-05-21T13:21:43.1234Z']"
+    "[event:good_ts_frac = t'2010-05-21T13:21:43.1234Z']",
+    "[event:good_ts in (t'1953-11-26T14:25:33Z', t'2010-05-21T13:21:43Z', t'2000-06-17T17:25:51.44Z')]",
+    "[event:good_ts not in (t'1953-11-26T14:25:33Z', t'1985-07-25T20:27:52Z', t'2000-06-17T17:25:51.44Z')]"
 ])
 def test_ts_match(pattern):
     assert match(pattern, _observations)
@@ -43,7 +45,9 @@ def test_ts_match(pattern):
     "[event:good_ts = t'1974-11-05T05:31:11Z']",
     "[event:good_ts <= t'1974-11-05T05:31:11Z']",
     "[event:good_ts >= t'3012-08-17T17:43:55Z']",
-    "[event:good_ts_frac != t'2010-05-21T13:21:43.1234Z']"
+    "[event:good_ts_frac != t'2010-05-21T13:21:43.1234Z']",
+    "[event:good_ts not in (t'1953-11-26T14:25:33Z', t'2010-05-21T13:21:43Z', t'2000-06-17T17:25:51.44Z')]",
+    "[event:good_ts in (t'1953-11-26T14:25:33Z', t'1985-07-25T20:27:52Z', t'2000-06-17T17:25:51.44Z')]"
 ])
 def test_ts_nomatch(pattern):
     assert not match(pattern, _observations)


### PR DESCRIPTION
 Added new tests to cover some of what the old test_pattern_matcher.py file used to cover.  test_basic_ops.py actually has *many* more tests than the old file, but still isn't a complete replacement.

These tests uncovered some issues, which are fixed:
- When a timestamp in a pattern is compared to a string from json, the matcher attempts to convert the json string to a timestamp.  The problem was that it wasn't checking if the json value actually was a string first.  Now, it does.  If the json value is not a string, the test result is 'false', not an error.  If the json value is a string, but is formatted incorrectly, that still results in an error.
- The above hackage was enabled for equality and order comparisons only.  With this PR, it is also added to set membership tests ('IN', 'NOT IN').
- To clarify the conditions under which the above hackage takes effect, homogeneity is now enforced on the types of the values in a set.  If all set members are not of the same type, an error is produced.  This is also  mentioned as a requirement in the spec.  So the condition is now: the matcher attempts to convert a json string value to a timestamp, if all set members are timestamps.
- The set hackage was easier to implement by checking the types of the python set contents, rather than checking token types as I'd done in the equality and order checking callbacks.  So to improve design consistency, I changed the impls in the equality and order callbacks to also check types of python values instead of token types.
- The above changes induced corresponding fixes in other tests.  E.g. tests which used heterogenous sets.  I also didn't have a timestamp test which used sets, so I added some.