### PR TITLE
Added a hack to reduce/eliminate the ugly "<INVALID>" tokens from parse errors

### DIFF
--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -1978,6 +1978,13 @@ def match(pattern, observed_data_sdos, verbose=False):
     # handling the built-in RecognitionException errors.)
     parser._errHandler = antlr4.BailErrorStrategy()
 
+    # To improve error messages, replace "<INVALID>" in the literal
+    # names with symbolic names.  This is a hack, but seemed like
+    # the simplest workaround.
+    for i, lit_name in enumerate(parser.literalNames):
+        if lit_name == u"<INVALID>":
+            parser.literalNames[i] = parser.symbolicNames[i]
+
     # parser.setTrace(True)
 
     matcher = MatchListener(observed_data_sdos, verbose)


### PR DESCRIPTION
It works by replacing "literal names" in the parser with "symbolic names", where the literal name is "&lt;INVALID&gt;".  It's a hack, but a very simple way to address the problem.  An example of an improved error message is:

```
__main__.MatcherException: 1:24: mismatched input '<EOF>' expecting {IntLiteral, FloatLiteral, HexLiteral, BinaryLiteral, StringLiteral, TimestampLiteral}
```

So it relies on nice descriptive lexer rule names.  But I think the lexer rule names are pretty good.