### PR TITLE
Improved temporal operators

### DIFF
--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -593,8 +593,8 @@ def _disjoint(first_seq, *rest_seq):
 
 
 # Constants used as return values of the _overlap() function.
-_OVERLAP_NONE        = 0
-_OVERLAP             = 1
+_OVERLAP_NONE = 0
+_OVERLAP = 1
 _OVERLAP_TOUCH_INNER = 2
 _OVERLAP_TOUCH_OUTER = 3
 _OVERLAP_TOUCH_POINT = 4
@@ -936,7 +936,7 @@ class MatchListener(STIXPatternListener):
         # doesn't make copies of observations; the same dict is repeated
         # several times in the list.  Same goes for the timestamps.
         self.__observations = []
-        self.__time_intervals = [] # 2-tuples of first,last timestamps
+        self.__time_intervals = []  # 2-tuples of first,last timestamps
         for sdo in observed_data_sdos:
 
             number_observed = sdo["number_observed"]
@@ -1332,7 +1332,7 @@ class MatchListener(STIXPatternListener):
             for binding in bindings:
                 in_bounds = all(
                     _overlap(start_time, stop_time, *self.__time_intervals[obs_id])
-                        in (_OVERLAP, _OVERLAP_TOUCH_OUTER)
+                    in (_OVERLAP, _OVERLAP_TOUCH_OUTER)
                     for obs_id in binding if obs_id is not None
                 )
 

--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -689,10 +689,10 @@ def _timestamp_intervals_within(timestamp_intervals, duration):
     # previously unoverlapped interval and obtain a solution, then we didn't
     # find the earliest last_observed time, which is a contradiction w.r.t. the
     # aforementioned construction of the test interval, so that's not possible
-    # either.  So it is impossible to find additional overlaps by moving the
-    # test interval either left or right; overlaps are maximized at our
-    # chosen test interval location.  Therefore our test interval must be a
-    # solution, if one exists.
+    # either.  So it is impossible to improve the overlap by moving the test
+    # interval either left or right; overlaps are maximized at our chosen test
+    # interval location.  Therefore our test interval must be a solution, if
+    # one exists.
 
     earliest_last_observed = min(interval[1] for interval in timestamp_intervals)
     test_interval = (earliest_last_observed, earliest_last_observed + duration)

--- a/stix2matcher/test/test_basic_ops.py
+++ b/stix2matcher/test/test_basic_ops.py
@@ -8,6 +8,7 @@ _observations = [
         "type": "observed-data",
         "number_observed": 1,
         "first_observed": "2014-04-19T06:51:26Z",
+        "last_observed": "2014-04-19T06:51:26Z",
         "objects": {
             "0": {
                 "type": "test",

--- a/stix2matcher/test/test_binary.py
+++ b/stix2matcher/test/test_binary.py
@@ -8,6 +8,7 @@ _observations = [
         "type": "observed-data",
         "number_observed": 1,
         "first_observed": "2011-12-03T21:34:41Z",
+        "last_observed": "2011-12-03T21:34:41Z",
         "objects": {
             "0": {
                 "type": "binary_test",

--- a/stix2matcher/test/test_comparison_exprs.py
+++ b/stix2matcher/test/test_comparison_exprs.py
@@ -8,6 +8,7 @@ _observations = [
         "type": "observed-data",
         "number_observed": 1,
         "first_observed": "2004-11-26T11:42:29Z",
+        "last_observed": "2004-11-26T11:42:29Z",
         "objects": {
             "0": {
                 "type": u"person",

--- a/stix2matcher/test/test_complex.py
+++ b/stix2matcher/test/test_complex.py
@@ -6,6 +6,7 @@ _observations = [
     {
         "type": "observed-data",
         "first_observed": "2004-10-11T21:44:58Z",
+        "last_observed": "2004-10-11T21:44:58Z",
         "number_observed": 2,
         "objects": {
             "a0": {
@@ -18,6 +19,7 @@ _observations = [
     {
         "type": "observed-data",
         "first_observed": "2004-10-11T21:45:01Z",
+        "last_observed": "2004-10-11T21:45:01Z",
         "number_observed": 3,
         "objects": {
             "b0": {
@@ -30,6 +32,7 @@ _observations = [
     {
         "type": "observed-data",
         "first_observed": "2004-10-11T21:45:02Z",
+        "last_observed": "2004-10-11T21:45:02Z",
         "number_observed": 2,
         "objects": {
             "c0": {

--- a/stix2matcher/test/test_matching_sdos.py
+++ b/stix2matcher/test/test_matching_sdos.py
@@ -9,6 +9,7 @@ _observations = [
         "id": "observed-data--a49751b8-b041-4c00-96c2-76af472bfbbe",
         "type": "observed-data",
         "first_observed": "1994-11-29T13:37:52Z",
+        "last_observed": "1994-11-29T13:37:52Z",
         "number_observed": 1,
         "objects": {
             "0": {
@@ -21,6 +22,7 @@ _observations = [
         "id": "observed-data--7d34018e-986c-4817-a2c5-21fe95284109",
         "type": "observed-data",
         "first_observed": "1994-11-29T13:37:57Z",
+        "last_observed": "1994-11-29T13:37:57Z",
         "number_observed": 1,
         "objects": {
             "0": {
@@ -33,6 +35,7 @@ _observations = [
         "id": "observed-data--52a5bab7-2cfd-40c6-a35a-b5bcb8afb11b",
         "type": "observed-data",
         "first_observed": "1994-11-29T13:38:02Z",
+        "last_observed": "1994-11-29T13:38:02Z",
         "number_observed": 1,
         "objects": {
             "0": {

--- a/stix2matcher/test/test_null.py
+++ b/stix2matcher/test/test_null.py
@@ -6,6 +6,7 @@ _observations = [
     {
         "type": "observed-data",
         "first_observed": "2005-10-09T21:44:58Z",
+        "last_observed": "2005-10-09T21:44:58Z",
         "number_observed": 1,
         "objects": {
             "0": {

--- a/stix2matcher/test/test_object_path_quoting.py
+++ b/stix2matcher/test/test_object_path_quoting.py
@@ -6,6 +6,7 @@ _observations = [
     {
         "type": "observed-data",
         "first_observed": "2004-10-11T21:44:58Z",
+        "last_observed": "2004-10-11T21:44:58Z",
         "number_observed": 1,
         "objects": {
             "0": {

--- a/stix2matcher/test/test_observation_exprs.py
+++ b/stix2matcher/test/test_observation_exprs.py
@@ -6,6 +6,7 @@ _observations = [
     {
         "type": "observed-data",
         "first_observed": "2004-10-11T21:44:58Z",
+        "last_observed": "2004-10-11T21:44:58Z",
         "number_observed": 1,
         "objects": {
             "a0": {
@@ -18,6 +19,7 @@ _observations = [
     {
         "type": "observed-data",
         "first_observed": "2008-05-09T01:21:58.6Z",
+        "last_observed": "2008-05-09T01:21:58.6Z",
         "number_observed": 1,
         "objects": {
             "b0": {
@@ -30,6 +32,7 @@ _observations = [
     {
         "type": "observed-data",
         "first_observed": "2006-11-03T07:42:18.96Z",
+        "last_observed": "2006-11-03T07:42:18.96Z",
         "number_observed": 1,
         "objects": {
             "c0": {

--- a/stix2matcher/test/test_references.py
+++ b/stix2matcher/test/test_references.py
@@ -7,6 +7,7 @@ _observations = [
         "type": "observed-data",
         "number_observed": 1,
         "first_observed": "1984-06-26T13:53:04Z",
+        "last_observed": "1984-06-26T13:53:04Z",
         "objects": {
             "0": {
                 "type": "person",

--- a/stix2matcher/test/test_temporal_qualifiers.py
+++ b/stix2matcher/test/test_temporal_qualifiers.py
@@ -2,6 +2,15 @@ import pytest
 
 from stix2matcher.matcher import match, MatcherException
 
+# I'll specially test some critical internal time-interval related code,
+# since it's easier to test it separately than create lots of SDOs and
+# patterns.
+from stix2matcher.matcher import (_overlap, _OVERLAP_NONE, _OVERLAP,
+                                  _OVERLAP_TOUCH_INNER, _OVERLAP_TOUCH_OUTER,
+                                  _OVERLAP_TOUCH_POINT)
+from stix2matcher.matcher import _timestamp_intervals_within
+
+
 _observations = [
     {
         "type": "observed-data",
@@ -101,13 +110,8 @@ def test_temp_qual_error(pattern):
         match(pattern, _observations)
 
 
-# Do some checking of critical code dealing with timestamp ranges.  It's
-# pretty generic and much easier to test with ints than timestamps.
-from stix2matcher.matcher import (_overlap, _OVERLAP_NONE, _OVERLAP,
-                                  _OVERLAP_TOUCH_INNER, _OVERLAP_TOUCH_OUTER,
-                                  _OVERLAP_TOUCH_POINT)
-from stix2matcher.matcher import _timestamp_intervals_within
-
+# The below tests use ints instead of timestamps.  The code is generic enough
+# and it's much easier to test with simple ints.
 
 @pytest.mark.parametrize("min1,max1,min2,max2,expected_overlap", [
     (1, 1, 1, 1, _OVERLAP_TOUCH_POINT),
@@ -210,4 +214,3 @@ def test_within_nomatch(interval1, interval2, duration):
     pattern = "([person:name='alice'] and [person:name='bob']) " \
               "within {0} seconds".format(duration)
     assert not match(pattern, _observations)
-

--- a/stix2matcher/test/test_temporal_qualifiers.py
+++ b/stix2matcher/test/test_temporal_qualifiers.py
@@ -6,6 +6,7 @@ _observations = [
     {
         "type": "observed-data",
         "first_observed": "1994-11-29T13:37:52Z",
+        "last_observed": "1994-11-29T13:37:52Z",
         "number_observed": 1,
         "objects": {
             "0": {
@@ -17,6 +18,7 @@ _observations = [
     {
         "type": "observed-data",
         "first_observed": "1994-11-29T13:37:57Z",
+        "last_observed": "1994-11-29T13:37:57Z",
         "number_observed": 1,
         "objects": {
             "0": {
@@ -28,6 +30,7 @@ _observations = [
     {
         "type": "observed-data",
         "first_observed": "1994-11-29T13:38:02Z",
+        "last_observed": "1994-11-29T13:38:02Z",
         "number_observed": 1,
         "objects": {
             "0": {
@@ -96,3 +99,115 @@ def test_temp_qual_nomatch(pattern):
 def test_temp_qual_error(pattern):
     with pytest.raises(MatcherException):
         match(pattern, _observations)
+
+
+# Do some checking of critical code dealing with timestamp ranges.  It's
+# pretty generic and much easier to test with ints than timestamps.
+from stix2matcher.matcher import (_overlap, _OVERLAP_NONE, _OVERLAP,
+                                  _OVERLAP_TOUCH_INNER, _OVERLAP_TOUCH_OUTER,
+                                  _OVERLAP_TOUCH_POINT)
+from stix2matcher.matcher import _timestamp_intervals_within
+
+
+@pytest.mark.parametrize("min1,max1,min2,max2,expected_overlap", [
+    (1, 1, 1, 1, _OVERLAP_TOUCH_POINT),
+    (1, 1, 1, 2, _OVERLAP_TOUCH_INNER),
+    (1, 2, 1, 1, _OVERLAP_TOUCH_OUTER),
+    (1, 2, 2, 2, _OVERLAP_TOUCH_INNER),
+    (2, 2, 1, 2, _OVERLAP_TOUCH_OUTER),
+    (1, 2, 2, 3, _OVERLAP_TOUCH_INNER),
+    (2, 3, 1, 2, _OVERLAP_TOUCH_OUTER),
+    (1, 2, 1, 3, _OVERLAP),
+    (1, 3, 1, 2, _OVERLAP),
+    (1, 3, 2, 3, _OVERLAP),
+    (2, 3, 1, 3, _OVERLAP),
+    (1, 3, 2, 4, _OVERLAP),
+    (2, 4, 1, 3, _OVERLAP),
+    (1, 4, 2, 3, _OVERLAP),
+    (2, 3, 1, 4, _OVERLAP),
+    (1, 3, 2, 2, _OVERLAP),
+    (2, 2, 1, 3, _OVERLAP),
+    (1, 2, 3, 4, _OVERLAP_NONE),
+    (3, 4, 1, 2, _OVERLAP_NONE)
+])
+def test_overlap(min1, max1, min2, max2, expected_overlap):
+    assert _overlap(min1, max1, min2, max2) == expected_overlap
+
+
+@pytest.mark.parametrize("intervals,duration", [
+    (((1, 1), (1, 1)), 0),
+    (((1, 1), (1, 1)), 1),
+    (((1, 1), (1, 2)), 1),
+    (((1, 2), (3, 4)), 1),
+    (((1, 4), (2, 3)), 1),
+    (((1, 3), (2, 4)), 1),
+    (((1, 2), (3, 4), (5, 6)), 4),
+    (((1, 4), (2, 3), (4, 5)), 1),
+    (((1, 2), (2, 3), (4, 5)), 2),
+    (((1, 2), (2, 3), (4, 5)), 3)
+])
+def test_intervals_within_match(intervals, duration):
+    assert _timestamp_intervals_within(intervals, duration)
+
+
+@pytest.mark.parametrize("intervals,duration", [
+    (((1, 2), (3, 4)), 0),
+    (((1, 2), (4, 5)), 1),
+    (((1, 2), (3, 4), (5, 6)), 2),
+    (((1, 5), (1, 2), (4, 5)), 1),
+    (((1, 2), (1, 3), (1, 4), (4, 5)), 1)
+])
+def test_intervals_within_nomatch(intervals, duration):
+    assert not _timestamp_intervals_within(intervals, duration)
+
+
+# For these tests, instead of keeping the data fixed and changing the
+# pattern, we adjust timestamps in the data to further exercise temporal
+# operations, and keep the pattern mostly fixed.
+_1 = "2000-01-01T00:00:00Z"
+_2 = "2000-01-01T00:00:01Z"
+_3 = "2000-01-01T00:00:02Z"
+_4 = "2000-01-01T00:00:03Z"
+_5 = "2000-01-01T00:00:04Z"
+
+
+@pytest.mark.parametrize("interval1,interval2,duration", [
+    ((_1, _1), (_1, _1), 1),
+    ((_1, _1), (_1, _2), 1),
+    ((_1, _1), (_1, _2), 2),
+    ((_1, _2), (_2, _3), 1),
+    ((_1, _2), (_3, _4), 1),
+    ((_1, _4), (_2, _3), 1),
+    ((_1, _3), (_2, _4), 1),
+    ((_1, _2), (_4, _5), 2),
+])
+def test_within_match(interval1, interval2, duration):
+
+    _observations[0]["first_observed"] = interval1[0]
+    _observations[0]["last_observed"] = interval1[1]
+
+    _observations[1]["first_observed"] = interval2[0]
+    _observations[1]["last_observed"] = interval2[1]
+
+    pattern = "([person:name='alice'] and [person:name='bob']) " \
+              "within {0} seconds".format(duration)
+    assert match(pattern, _observations)
+
+
+@pytest.mark.parametrize("interval1,interval2,duration", [
+    ((_1, _2), (_4, _5), 1),
+    ((_1, _1), (_4, _5), 2),
+    ((_1, _2), (_5, _5), 2),
+])
+def test_within_nomatch(interval1, interval2, duration):
+
+    _observations[0]["first_observed"] = interval1[0]
+    _observations[0]["last_observed"] = interval1[1]
+
+    _observations[1]["first_observed"] = interval2[0]
+    _observations[1]["last_observed"] = interval2[1]
+
+    pattern = "([person:name='alice'] and [person:name='bob']) " \
+              "within {0} seconds".format(duration)
+    assert not match(pattern, _observations)
+

--- a/stix2matcher/test/test_timestamps.py
+++ b/stix2matcher/test/test_timestamps.py
@@ -6,6 +6,7 @@ _observations = [
     {
         "type": "observed-data",
         "first_observed": "1983-04-21T15:31:06Z",
+        "last_observed": "1983-04-21T15:31:06Z",
         "number_observed": 1,
         "objects": {
             "0": {

--- a/stix2matcher/test/test_unicode_normalization.py
+++ b/stix2matcher/test/test_unicode_normalization.py
@@ -6,6 +6,7 @@ _observations = [
     {
         "type": "cybox-container",
         "first_observed": "2011-08-08T20:02:48Z",
+        "last_observed": "2011-08-08T20:02:48Z",
         "number_observed": 1,
         "objects": {
             "0": {


### PR DESCRIPTION
This PR improves the behavior of the matcher with respect to temporal operators and qualifiers.  Both first and last observed timestamps on SDOs are now used.  A more sophisticated approach is taken which will allow more matches than before: if it is possible to choose a legal timestamp (i.e. between first_observed and last_observed inclusive) for each observation such that the the temporal constraints are satisfied, then the observation(s) pass the test.