### PR TITLE
Add support for the 'NOT' qualifier before equality and order comparison operators.

### DIFF
--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -1514,6 +1514,9 @@ class MatchListener(STIXPatternListener):
             if ctx.NEQ():
                 result = not result
 
+            if ctx.NOT():
+                result = not result
+
             return result
 
         passed_obs = _obs_map_prop_test(obs_values, equality_pred)
@@ -1589,6 +1592,9 @@ class MatchListener(STIXPatternListener):
                 else:
                     # shouldn't ever happen, right?
                     raise UnsupportedOperatorError(op_str)
+
+            if ctx.NOT():
+                result = not result
 
             return result
 

--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -1482,8 +1482,10 @@ class MatchListener(STIXPatternListener):
         literal_node = ctx.primitiveLiteral()
         literal_terminal = _get_first_terminal_descendant(literal_node)
         literal_value = _literal_terminal_to_python_val(literal_terminal)
-        debug_label = u"exitPropTestEqual ({} {})".format(
-            ctx.getChild(1).getText(),
+        op_tok = ctx.EQ() or ctx.NEQ()
+        debug_label = u"exitPropTestEqual ({}{} {})".format(
+            u"NOT " if ctx.NOT() else u"",
+            op_tok.getText(),
             literal_terminal.getText()
         )
 
@@ -1543,9 +1545,10 @@ class MatchListener(STIXPatternListener):
         literal_node = ctx.orderableLiteral()
         literal_terminal = _get_first_terminal_descendant(literal_node)
         literal_value = _literal_terminal_to_python_val(literal_terminal)
-        op_str = ctx.getChild(1).getText()
-        debug_label = u"exitPropTestOrder ('{}' {})".format(
-            op_str,
+        op_tok = ctx.GT() or ctx.LT() or ctx.GE() or ctx.LE()
+        debug_label = u"exitPropTestOrder ({}{} {})".format(
+            u"NOT " if ctx.NOT() else u"",
+            op_tok.getText(),
             literal_terminal.getText()
         )
 

--- a/stix2matcher/test/test_basic_ops.py
+++ b/stix2matcher/test/test_basic_ops.py
@@ -26,14 +26,19 @@ _observations = [
 
 
 @pytest.mark.parametrize("pattern", [
+    "[test:int = 5]",
+    "[test:int not != 5]",
     "[test:int > 3]",
+    "[test:int not < 3]",
     "[test:int < 12]",
     "[test:int > 4.9]",
     "[test:int < 5.1]",
     "[test:int >= 5]",
+    "[test:int not < 5]",
     "[test:int <= 5]",
     "[test:int != false]",
     "[test:int != true]",
+    "[test:int not = true]",
     "[test:int != 'world']",
     "[test:int != h'010203']",
     "[test:int != b'AQIDBA==']",
@@ -47,6 +52,8 @@ def test_basic_ops_int_match(pattern):
 
 
 @pytest.mark.parametrize("pattern", [
+    "[test:int not = 5]",
+    "[test:int not != 8]",
     "[test:int > 8]",
     "[test:int < 2]",
     "[test:int > 5.1]",
@@ -73,7 +80,10 @@ def test_basic_ops_int_nomatch(pattern):
 
 
 @pytest.mark.parametrize("pattern", [
+    "[test:float = 12.658]",
+    "[test:float not != 12.658]",
     "[test:float > 3]",
+    "[test:float not < 3]",
     "[test:float < 22]",
     "[test:float > 12.65799]",
     "[test:float < 12.65801]",
@@ -95,6 +105,8 @@ def test_basic_ops_float_match(pattern):
 
 
 @pytest.mark.parametrize("pattern", [
+    "[test:float not = 12.658]",
+    "[test:float != 12.658]",
     "[test:float > 22]",
     "[test:float < 3]",
     "[test:float > 12.65801]",
@@ -102,6 +114,7 @@ def test_basic_ops_float_match(pattern):
     "[test:float = false]",
     "[test:float = true]",
     "[test:float = 'world']",
+    "[test:float not != 'world']",
     "[test:float = h'010203']",
     "[test:float > h'010203']",
     "[test:float = b'AQIDBA==']",
@@ -125,7 +138,9 @@ def test_basic_ops_float_nomatch(pattern):
     "[test:bool != 1]",
     "[test:bool != 32.567]",
     "[test:bool = true]",
+    "[test:bool not != true]",
     "[test:bool != false]",
+    "[test:bool not = false]",
     "[test:bool != 'world']",
     "[test:bool != h'010203']",
     "[test:bool != b'AQIDBA==']",
@@ -141,7 +156,9 @@ def test_basic_ops_bool_match(pattern):
     "[test:bool = 1]",
     "[test:bool = 32.567]",
     "[test:bool != true]",
+    "[test:bool not = true]",
     "[test:bool = false]",
+    "[test:bool not != false]",
     "[test:bool = 'world']",
     "[test:bool = h'010203']",
     "[test:bool = b'AQIDBA==']",
@@ -163,7 +180,9 @@ def test_basic_ops_bool_nomatch(pattern):
     "[test:string != true]",
     "[test:string != false]",
     "[test:string = 'hello']",
+    "[test:string not != 'hello']",
     "[test:string != 'world']",
+    "[test:string not = 'world']",
     "[test:string > 'alice']",
     "[test:string < 'zelda']",
     "[test:string >= 'hello']",
@@ -187,7 +206,9 @@ def test_basic_ops_string_match(pattern):
     "[test:string = true]",
     "[test:string = false]",
     "[test:string != 'hello']",
+    "[test:string not = 'hello']",
     "[test:string = 'world']",
+    "[test:string not != 'world']",
     "[test:string < 'alice']",
     "[test:string > 'zelda']",
     "[test:string <= 'alice']",


### PR DESCRIPTION
Changes corresponding to the latest grammar update, to add support
for the 'NOT' qualifier before equality and order comparison
operators.  Sprinkled some additional tests using this syntax into
test_basic_ops.py.