### PR TITLE
Fix a little bug in an exception message

### DIFF
--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -1594,7 +1594,7 @@ class MatchListener(STIXPatternListener):
                     result = result >= 0
                 else:
                     # shouldn't ever happen, right?
-                    raise UnsupportedOperatorError(op_str)
+                    raise UnsupportedOperatorError(op_tok.getText())
 
             if ctx.NOT():
                 result = not result


### PR DESCRIPTION
Fix a little bug that was introduced when I added support for 'NOT' before equality and order comparison operators.  It's only about an exception message, and in a code branch that probably will never be executed.  So, it's a minor thing.