### PR TITLE
Change the Pattern.match() method to call self.walk()

### DIFF
--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -2122,7 +2122,7 @@ class Pattern(stix2patterns.pattern.Pattern):
         :raises MatcherException: If an error occurs during matching
         """
         matcher = MatchListener(observed_data_sdos, verbose)
-        antlr4.ParseTreeWalker.DEFAULT.walk(matcher, self.__parse_tree)
+        self.walk(matcher)
 
         found_bindings = matcher.matched()
         if found_bindings:


### PR DESCRIPTION
... instead of trying to access self.__parse_tree directly.

Other part of the fix for [cti-pattern-validator issue #32](https://github.com/oasis-open/cti-pattern-validator/issues/32).