### PR TITLE
Fixed matcher according to pattern grammar changes (related to int and float tokens)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         'antlr4-python3-runtime==4.7 ; python_version >= "3"',
         'python-dateutil',
         'six',
-        'stix2-patterns>=0.6.0',
+        'stix2-patterns>=1.0.0',
         'typing ; python_version < "3.5" and python_version >= "3"',
     ],
     tests_require=[

--- a/stix2matcher/test/test_basic_ops.py
+++ b/stix2matcher/test/test_basic_ops.py
@@ -25,35 +25,35 @@ _observations = [
 
 @pytest.mark.parametrize("pattern", [
     "[test:int = 5]",
-    "[test:int not != 5]",
+    "[test:int NOT != 5]",
     "[test:int > 3]",
-    "[test:int not < 3]",
+    "[test:int NOT < 3]",
     "[test:int < 12]",
     "[test:int > 4.9]",
     "[test:int < 5.1]",
     "[test:int >= 5]",
-    "[test:int not < 5]",
+    "[test:int NOT < 5]",
     "[test:int <= 5]",
     "[test:int != false]",
     "[test:int != true]",
-    "[test:int not = true]",
+    "[test:int NOT = true]",
     "[test:int != 'world']",
     "[test:int != h'010203']",
     "[test:int != b'AQIDBA==']",
     "[test:int != t'1965-07-19T22:41:38Z']",
-    "[test:int in (-4, 5, 6)]",
-    "[test:int in (-4, 5, 6.6)]",
-    "[test:int not in ('a', 'b', 'c')]",
-    "[test:int not matches 'l+']",
-    "[test:int not like 'he%']",
+    "[test:int IN (-4, 5, 6)]",
+    "[test:int IN (-4, 5, 6.6)]",
+    "[test:int NOT IN ('a', 'b', 'c')]",
+    "[test:int NOT MATCHES 'l+']",
+    "[test:int NOT LIKE 'he%']",
 ])
 def test_basic_ops_int_match(pattern):
     assert match(pattern, _observations)
 
 
 @pytest.mark.parametrize("pattern", [
-    "[test:int not = 5]",
-    "[test:int not != 8]",
+    "[test:int NOT = 5]",
+    "[test:int NOT != 8]",
     "[test:int > 8]",
     "[test:int < 2]",
     "[test:int > 5.1]",
@@ -67,11 +67,11 @@ def test_basic_ops_int_match(pattern):
     "[test:int < b'AQIDBA==']",
     "[test:int = t'1965-07-19T22:41:38Z']",
     "[test:int > t'1965-07-19T22:41:38Z']",
-    "[test:int like 'he%']",
-    "[test:int matches 'l+']",
-    "[test:int not in (-4, 5, 6)]",
-    "[test:int not in (-4, 5, 6.6)]",
-    "[test:int in ('a', 'b', 'c')]"
+    "[test:int LIKE 'he%']",
+    "[test:int MATCHES 'l+']",
+    "[test:int NOT IN (-4, 5, 6)]",
+    "[test:int NOT IN (-4, 5, 6.6)]",
+    "[test:int IN ('a', 'b', 'c')]"
 ])
 def test_basic_ops_int_nomatch(pattern):
     assert not match(pattern, _observations)
@@ -79,9 +79,9 @@ def test_basic_ops_int_nomatch(pattern):
 
 @pytest.mark.parametrize("pattern", [
     "[test:float = 12.658]",
-    "[test:float not != 12.658]",
+    "[test:float NOT != 12.658]",
     "[test:float > 3]",
-    "[test:float not < 3]",
+    "[test:float NOT < 3]",
     "[test:float < 22]",
     "[test:float > 12.65799]",
     "[test:float < 12.65801]",
@@ -93,19 +93,19 @@ def test_basic_ops_int_nomatch(pattern):
     "[test:float != h'010203']",
     "[test:float != b'AQIDBA==']",
     "[test:float != t'1965-07-19T22:41:38Z']",
-    "[test:float in (-4.21, 12.658, 964.321)]",
-    "[test:float_int in (11, 12, 13)]",
-    "[test:float_int in (11.1, 12, 13)]",
-    "[test:float not in ('a', 'b', 'c')]",
-    "[test:float not matches 'l+']",
-    "[test:float not like 'he%']",
+    "[test:float IN (-4.21, 12.658, 964.321)]",
+    "[test:float_int IN (11, 12, 13)]",
+    "[test:float_int IN (11.1, 12, 13)]",
+    "[test:float NOT IN ('a', 'b', 'c')]",
+    "[test:float NOT MATCHES 'l+']",
+    "[test:float NOT LIKE 'he%']",
 ])
 def test_basic_ops_float_match(pattern):
     assert match(pattern, _observations)
 
 
 @pytest.mark.parametrize("pattern", [
-    "[test:float not = 12.658]",
+    "[test:float NOT = 12.658]",
     "[test:float != 12.658]",
     "[test:float > 22]",
     "[test:float < 3]",
@@ -114,19 +114,19 @@ def test_basic_ops_float_match(pattern):
     "[test:float = false]",
     "[test:float = true]",
     "[test:float = 'world']",
-    "[test:float not != 'world']",
+    "[test:float NOT != 'world']",
     "[test:float = h'010203']",
     "[test:float > h'010203']",
     "[test:float = b'AQIDBA==']",
     "[test:float < b'AQIDBA==']",
     "[test:float = t'1965-07-19T22:41:38Z']",
     "[test:float > t'1965-07-19T22:41:38Z']",
-    "[test:float like 'he%']",
-    "[test:float matches 'l+']",
-    "[test:float not in (-4.21, 12.658, 964.321)]",
-    "[test:float_int not in (11, 12, 13)]",
-    "[test:float_int not in (11.1, 12, 13)]",
-    "[test:float in ('a', 'b', 'c')]"
+    "[test:float LIKE 'he%']",
+    "[test:float MATCHES 'l+']",
+    "[test:float NOT IN (-4.21, 12.658, 964.321)]",
+    "[test:float_int NOT IN (11, 12, 13)]",
+    "[test:float_int NOT IN (11.1, 12, 13)]",
+    "[test:float IN ('a', 'b', 'c')]"
 ])
 def test_basic_ops_float_nomatch(pattern):
     assert not match(pattern, _observations)
@@ -136,17 +136,17 @@ def test_basic_ops_float_nomatch(pattern):
     "[test:bool != 1]",
     "[test:bool != 32.567]",
     "[test:bool = true]",
-    "[test:bool not != true]",
+    "[test:bool NOT != true]",
     "[test:bool != false]",
-    "[test:bool not = false]",
+    "[test:bool NOT = false]",
     "[test:bool != 'world']",
     "[test:bool != h'010203']",
     "[test:bool != b'AQIDBA==']",
     "[test:bool != t'1965-07-19T22:41:38Z']",
-    "[test:bool in (false, true, false)]",
-    "[test:bool not in ('a', 'b', 'c')]",
-    "[test:bool not matches 'l+']",
-    "[test:bool not like 'he%']",
+    "[test:bool IN (false, true, false)]",
+    "[test:bool NOT IN ('a', 'b', 'c')]",
+    "[test:bool NOT MATCHES 'l+']",
+    "[test:bool NOT LIKE 'he%']",
 ])
 def test_basic_ops_bool_match(pattern):
     assert match(pattern, _observations)
@@ -156,17 +156,17 @@ def test_basic_ops_bool_match(pattern):
     "[test:bool = 1]",
     "[test:bool = 32.567]",
     "[test:bool != true]",
-    "[test:bool not = true]",
+    "[test:bool NOT = true]",
     "[test:bool = false]",
-    "[test:bool not != false]",
+    "[test:bool NOT != false]",
     "[test:bool = 'world']",
     "[test:bool = h'010203']",
     "[test:bool = b'AQIDBA==']",
     "[test:bool = t'1965-07-19T22:41:38Z']",
-    "[test:bool like 'he%']",
-    "[test:bool matches 'l+']",
-    "[test:bool not in (false, true, false)]",
-    "[test:bool in ('a', 'b', 'c')]"
+    "[test:bool LIKE 'he%']",
+    "[test:bool MATCHES 'l+']",
+    "[test:bool NOT IN (false, true, false)]",
+    "[test:bool IN ('a', 'b', 'c')]"
 ])
 def test_basic_ops_bool_nomatch(pattern):
     assert not match(pattern, _observations)
@@ -178,21 +178,21 @@ def test_basic_ops_bool_nomatch(pattern):
     "[test:string != true]",
     "[test:string != false]",
     "[test:string = 'hello']",
-    "[test:string not != 'hello']",
+    "[test:string NOT != 'hello']",
     "[test:string != 'world']",
-    "[test:string not = 'world']",
+    "[test:string NOT = 'world']",
     "[test:string > 'alice']",
     "[test:string < 'zelda']",
     "[test:string >= 'hello']",
     "[test:string <= 'hello']",
     "[test:string != h'010203']",
     "[test:string != b'AQIDBA==']",
-    "[test:string like 'he%']",
-    "[test:string like 'he__o']",
-    "[test:string matches 'l+']",
-    "[test:string matches '.lo$']",
-    "[test:string in ('goodbye', 'hello', 'world')]",
-    "[test:string not in (1, 2, 3)]"
+    "[test:string LIKE 'he%']",
+    "[test:string LIKE 'he__o']",
+    "[test:string MATCHES 'l+']",
+    "[test:string MATCHES '.lo$']",
+    "[test:string IN ('goodbye', 'hello', 'world')]",
+    "[test:string NOT IN (1, 2, 3)]"
 ])
 def test_basic_ops_string_match(pattern):
     assert match(pattern, _observations)
@@ -204,21 +204,21 @@ def test_basic_ops_string_match(pattern):
     "[test:string = true]",
     "[test:string = false]",
     "[test:string != 'hello']",
-    "[test:string not = 'hello']",
+    "[test:string NOT = 'hello']",
     "[test:string = 'world']",
-    "[test:string not != 'world']",
+    "[test:string NOT != 'world']",
     "[test:string < 'alice']",
     "[test:string > 'zelda']",
     "[test:string <= 'alice']",
     "[test:string >= 'zelda']",
     "[test:string = h'010203']",
     "[test:string = b'AQIDBA==']",
-    "[test:string not like 'he%']",
-    "[test:string not like 'he__o']",
-    "[test:string not matches 'l+']",
-    "[test:string not matches '.lo$']",
-    "[test:string not in ('goodbye', 'hello', 'world')]",
-    "[test:string in (1, 2, 3)]"
+    "[test:string NOT LIKE 'he%']",
+    "[test:string NOT LIKE 'he__o']",
+    "[test:string NOT MATCHES 'l+']",
+    "[test:string NOT MATCHES '.lo$']",
+    "[test:string NOT IN ('goodbye', 'hello', 'world')]",
+    "[test:string IN (1, 2, 3)]"
 ])
 def test_basic_ops_string_nomatch(pattern):
     assert not match(pattern, _observations)
@@ -243,50 +243,50 @@ def test_basic_ops_string_err(pattern):
 
 
 @pytest.mark.parametrize("pattern", [
-    "[test:ip issubset '11.22.41.123/20']",
-    "[test:ip not issubset '11.22.123.41/20']",
-    "[test:cidr issuperset '11.22.41.123']",
-    "[test:cidr issuperset '11.22.41.123/29']",
-    "[test:cidr not issuperset '11.22.33.44/13']",
-    "[test:cidr not issuperset '11.22.123.41/29']",
-    "[test:int not issuperset '11.22.33.44']",
-    "[test:int not issubset '11.22.33.44']",
-    "[test:float not issuperset '11.22.33.44']",
-    "[test:float not issubset '11.22.33.44']",
-    "[test:bool not issuperset '11.22.33.44']",
-    "[test:bool not issubset '11.22.33.44']",
+    "[test:ip ISSUBSET '11.22.41.123/20']",
+    "[test:ip NOT ISSUBSET '11.22.123.41/20']",
+    "[test:cidr ISSUPERSET '11.22.41.123']",
+    "[test:cidr ISSUPERSET '11.22.41.123/29']",
+    "[test:cidr NOT ISSUPERSET '11.22.33.44/13']",
+    "[test:cidr NOT ISSUPERSET '11.22.123.41/29']",
+    "[test:int NOT ISSUPERSET '11.22.33.44']",
+    "[test:int NOT ISSUBSET '11.22.33.44']",
+    "[test:float NOT ISSUPERSET '11.22.33.44']",
+    "[test:float NOT ISSUBSET '11.22.33.44']",
+    "[test:bool NOT ISSUPERSET '11.22.33.44']",
+    "[test:bool NOT ISSUBSET '11.22.33.44']",
 ])
 def test_basic_ops_ip_match(pattern):
     assert match(pattern, _observations)
 
 
 @pytest.mark.parametrize("pattern", [
-    "[test:ip not issubset '11.22.41.123/20']",
-    "[test:ip issubset '11.22.123.41/20']",
-    "[test:cidr not issuperset '11.22.41.123']",
-    "[test:cidr not issuperset '11.22.41.123/29']",
-    "[test:cidr issuperset '11.22.33.44/13']",
-    "[test:cidr issuperset '11.22.123.41/29']",
-    "[test:int issuperset '11.22.33.44']",
-    "[test:int issubset '11.22.33.44']",
-    "[test:float issuperset '11.22.33.44']",
-    "[test:float issubset '11.22.33.44']",
-    "[test:bool issuperset '11.22.33.44']",
-    "[test:bool issubset '11.22.33.44']",
+    "[test:ip NOT ISSUBSET '11.22.41.123/20']",
+    "[test:ip ISSUBSET '11.22.123.41/20']",
+    "[test:cidr NOT ISSUPERSET '11.22.41.123']",
+    "[test:cidr NOT ISSUPERSET '11.22.41.123/29']",
+    "[test:cidr ISSUPERSET '11.22.33.44/13']",
+    "[test:cidr ISSUPERSET '11.22.123.41/29']",
+    "[test:int ISSUPERSET '11.22.33.44']",
+    "[test:int ISSUBSET '11.22.33.44']",
+    "[test:float ISSUPERSET '11.22.33.44']",
+    "[test:float ISSUBSET '11.22.33.44']",
+    "[test:bool ISSUPERSET '11.22.33.44']",
+    "[test:bool ISSUBSET '11.22.33.44']",
 ])
 def test_basic_ops_ip_nomatch(pattern):
     assert not match(pattern, _observations)
 
 
 @pytest.mark.parametrize("pattern", [
-    "[test:string not in ()]"
+    "[test:string NOT IN ()]"
 ])
 def test_basic_ops_emptyset_match(pattern):
     assert match(pattern, _observations)
 
 
 @pytest.mark.parametrize("pattern", [
-    "[test:string in ()]"
+    "[test:string IN ()]"
 ])
 def test_basic_ops_emptyset_nomatch(pattern):
     assert not match(pattern, _observations)
@@ -294,9 +294,9 @@ def test_basic_ops_emptyset_nomatch(pattern):
 
 @pytest.mark.parametrize("pattern", [
     # Sets are required to contain elements of a single type.
-    "[test:string in (1, true)]",
-    "[test:string in (1, 2.2, true)]",
-    "[test:string in (1.1, 2.2, true)]",
+    "[test:string IN (1, true)]",
+    "[test:string IN (1, 2.2, true)]",
+    "[test:string IN (1.1, 2.2, true)]",
 ])
 def test_basic_ops_set_err(pattern):
     with pytest.raises(MatcherException):

--- a/stix2matcher/test/test_binary.py
+++ b/stix2matcher/test/test_binary.py
@@ -40,34 +40,34 @@ _observations = [
     "[binary_test:name_hex > b'YWFyZHZhcms=']",
     "[binary_test:name_hex > 'aardvark']",
 
-    "[binary_test:name_hex matches '\\\\x61li[c\\\\x01]e']",
-    "[binary_test:name_bin matches '\\\\x61li[c\\\\x01]e']",
-    "[binary_test:name_bin not matches '\\\\x62o[b\\\\x01]']",
-    u"[binary_test:name_bin not matches '\u0103lice']",
+    "[binary_test:name_hex MATCHES '\\\\x61li[c\\\\x01]e']",
+    "[binary_test:name_bin MATCHES '\\\\x61li[c\\\\x01]e']",
+    "[binary_test:name_bin NOT MATCHES '\\\\x62o[b\\\\x01]']",
+    u"[binary_test:name_bin NOT MATCHES '\u0103lice']",
 
     # some nonprintable binary data tests too.
     "[binary_test:bin_hex = h'01020304']",
     "[binary_test:bin_hex = b'AQIDBA==']",
     "[binary_test:bin_hex = '\x01\x02\x03\x04']",
-    "[binary_test:bin_hex matches '.*\\\\x03']",
+    "[binary_test:bin_hex MATCHES '.*\\\\x03']",
 ])
 def test_binary_match(pattern):
     assert match(pattern, _observations)
 
 
 @pytest.mark.parametrize("pattern", [
-    "[binary_test:name_bin matches '\\\\x62o[b\\\\x01]']",
-    "[binary_test:name_hex not matches '\\\\x61li[c\\\\x01]e']",
+    "[binary_test:name_bin MATCHES '\\\\x62o[b\\\\x01]']",
+    "[binary_test:name_hex NOT MATCHES '\\\\x61li[c\\\\x01]e']",
 
     # test codepoint >= 256, in both pattern and json
     u"[binary_test:name_bin = '\u0103lice']",
     u"[binary_test:name_bin > '\u0103lice']",
     u"[binary_test:name_bin < '\u0103lice']",
-    u"[binary_test:name_bin matches '\u0103lice']",
+    u"[binary_test:name_bin MATCHES '\u0103lice']",
     u"[binary_test:name_hex = '\u0103lice']",
     u"[binary_test:name_hex > '\u0103lice']",
     u"[binary_test:name_hex < '\u0103lice']",
-    u"[binary_test:name_hex matches '\u0103lice']",
+    u"[binary_test:name_hex MATCHES '\u0103lice']",
     u"[binary_test:name_u = h'616c696365']",
     u"[binary_test:name_u > h'616c696365']",
     u"[binary_test:name_u < h'616c696365']",

--- a/stix2matcher/test/test_comparison_exprs.py
+++ b/stix2matcher/test/test_comparison_exprs.py
@@ -24,21 +24,21 @@ _observations = [
 
 
 @pytest.mark.parametrize("pattern", [
-    "[person:name = 'alice' and person:age < 20]",
-    "[person:name = 'alice' or person:age > 20]",
-    "[person:name = 'alice' or person:age > 1000 and person:age < 0]",
-    "[(person:name = 'carol' or person:name = 'bob') and person:age > 10]",
-    "[(person:name = 'darlene' or person:name = 'carol') and person:age < 0 or person:age > 5]"
+    "[person:name = 'alice' AND person:age < 20]",
+    "[person:name = 'alice' OR person:age > 20]",
+    "[person:name = 'alice' OR person:age > 1000 AND person:age < 0]",
+    "[(person:name = 'carol' OR person:name = 'bob') AND person:age > 10]",
+    "[(person:name = 'darlene' OR person:name = 'carol') AND person:age < 0 OR person:age > 5]"
 ])
 def test_comparison_and_or_match(pattern):
     assert match(pattern, _observations)
 
 
 @pytest.mark.parametrize("pattern", [
-    "[person:name = 'alice' and person:age > 10]",
-    "[person:name = 'carol' or person:age > 20]",
-    "[(person:age = 'alice' or person:age > 1000) and person:age < 0]",
-    "[(person:name = 'darlene' or person:name = 'carol') and (person:age < 0 or person:age > 5)]"
+    "[person:name = 'alice' AND person:age > 10]",
+    "[person:name = 'carol' OR person:age > 20]",
+    "[(person:age = 'alice' OR person:age > 1000) AND person:age < 0]",
+    "[(person:name = 'darlene' OR person:name = 'carol') AND (person:age < 0 OR person:age > 5)]"
 ])
 def test_comparison_and_or_nomatch(pattern):
     assert not match(pattern, _observations)

--- a/stix2matcher/test/test_complex.py
+++ b/stix2matcher/test/test_complex.py
@@ -47,18 +47,18 @@ _observations = [
 # These SDOs have number_observed > 1; these patterns require contributions
 # of several observations from several SDOs to satisfy.
 @pytest.mark.parametrize("pattern", [
-    "[person:age < 20] repeats 5 times",
-    "[person:age < 20] repeats 2 times repeats 2 times",
-    "[person:name > 'aaron'] repeats 5 times within 1 seconds",
-    "([person:age < 30] and [person:name > 'aaron']) within 2 seconds repeats 3 times",
+    "[person:age < 20] REPEATS 5 TIMES",
+    "[person:age < 20] REPEATS 2 TIMES REPEATS 2 TIMES",
+    "[person:name > 'aaron'] REPEATS 5 TIMES WITHIN 1 SECONDS",
+    "([person:age < 30] AND [person:name > 'aaron']) WITHIN 2 SECONDS REPEATS 3 TIMES",
 ])
 def test_complex_match(pattern):
     assert match(pattern, _observations)
 
 
 @pytest.mark.parametrize("pattern", [
-    "[person:age < 20] repeats 10 times",
-    "[person:age < 20] repeats 2 times repeats 3 times"
+    "[person:age < 20] REPEATS 10 TIMES",
+    "[person:age < 20] REPEATS 2 TIMES REPEATS 3 TIMES"
 ])
 def test_complex_nomatch(pattern):
     assert not match(pattern, _observations)

--- a/stix2matcher/test/test_matching_sdos.py
+++ b/stix2matcher/test/test_matching_sdos.py
@@ -52,10 +52,10 @@ _observations = [
     # only one binding is possible for each pattern.
     ("[person:name='alice']",
      "observed-data--a49751b8-b041-4c00-96c2-76af472bfbbe"),
-    ("[person:name='bob'] and [person:name='carol']",
+    ("[person:name='bob'] AND [person:name='carol']",
         ("observed-data--7d34018e-986c-4817-a2c5-21fe95284109",
          "observed-data--52a5bab7-2cfd-40c6-a35a-b5bcb8afb11b")),
-    ("[person:name='carol'] or [person:name>'zelda']",
+    ("[person:name='carol'] OR [person:name>'zelda']",
      "observed-data--52a5bab7-2cfd-40c6-a35a-b5bcb8afb11b")
 ])
 def test_matching_sdos(pattern, expected_ids):

--- a/stix2matcher/test/test_null.py
+++ b/stix2matcher/test/test_null.py
@@ -23,11 +23,11 @@ _observations = [
     "[null_test:name > 'alice']",
     "[null_test:name <= 'alice']",
     "[null_test:name = 'alice']",
-    "[null_test:name in ('alice', 'bob', 'carol')]",
-    "[null_test:name like 'alice']",
-    "[null_test:name matches 'alice']",
-    "[null_test:name issubset '12.23.32.12/14']",
-    "[null_test:name issuperset '12.23.32.12/14']"
+    "[null_test:name IN ('alice', 'bob', 'carol')]",
+    "[null_test:name LIKE 'alice']",
+    "[null_test:name MATCHES 'alice']",
+    "[null_test:name ISSUBSET '12.23.32.12/14']",
+    "[null_test:name ISSUPERSET '12.23.32.12/14']"
 ])
 def test_null_json(pattern):
     assert not match(pattern, _observations)
@@ -42,11 +42,11 @@ def test_notequal_null_json(pattern):
 
 @pytest.mark.parametrize("pattern", [
     "[null_test:name = null]",
-    "[null_test:name in (null, null, null)]",
-    "[null_test:name like null]",
-    "[null_test:name matches null]",
-    "[null_test:name issubset null]",
-    "[null_test:name issuperset null]"
+    "[null_test:name IN (null, null, null)]",
+    "[null_test:name LIKE null]",
+    "[null_test:name MATCHES null]",
+    "[null_test:name ISSUBSET null]",
+    "[null_test:name ISSUPERSET null]"
 ])
 def test_null_pattern(pattern):
     with pytest.raises(ParseException):

--- a/stix2matcher/test/test_observation_exprs.py
+++ b/stix2matcher/test/test_observation_exprs.py
@@ -45,29 +45,29 @@ _observations = [
 
 
 @pytest.mark.parametrize("pattern", [
-    "[person:name='alice'] and [person:age>20]",
-    "[person:name='alice'] or [person:name='carol']",
-    "[person:name='alice'] or [person:name='zelda']",
-    "[person:age>10] or [person:name='bob'] or [person:name>'amber']",
-    "[person:name='alice'] followedby [person:name>'bill']",
-    "[person:age > 20] or ([person:name > 'zelda'] followedby [person:age < 0])",
-    "[person:age > 20] or [person:name > 'zelda'] and [person:age < 0]",
-    "([person:name='carol'] followedby [person:name < 'elizabeth']) and [person:age < 15]"
+    "[person:name='alice'] AND [person:age>20]",
+    "[person:name='alice'] OR [person:name='carol']",
+    "[person:name='alice'] OR [person:name='zelda']",
+    "[person:age>10] OR [person:name='bob'] OR [person:name>'amber']",
+    "[person:name='alice'] FOLLOWEDBY [person:name>'bill']",
+    "[person:age > 20] OR ([person:name > 'zelda'] FOLLOWEDBY [person:age < 0])",
+    "[person:age > 20] OR [person:name > 'zelda'] AND [person:age < 0]",
+    "([person:name='carol'] FOLLOWEDBY [person:name < 'elizabeth']) AND [person:age < 15]"
 ])
 def test_observation_ops_match(pattern):
     assert match(pattern, _observations)
 
 
 @pytest.mark.parametrize("pattern", [
-    "[person:name='alice'] and [person:name='zelda']",
-    "[person:name='alice'] and [person:age=10]",
-    "[person:name='alice'] followedby [person:age=10]",
-    "[person:name='mary'] or [person:name='zelda']",
-    "[person:age > 70] or [person:name > 'zelda'] and [person:name MATCHES '^...?$']",
-    "[person:name='bob'] followedby [person:age<15]",
-    "[person:age > 20] or [person:name > 'zelda'] followedby [person:age < 0]",
-    "([person:age > 20] or [person:name > 'zelda']) and [person:age < 0]",
-    "[person:name='carol'] followedby [person:name < 'elizabeth'] and [person:age < 15]"
+    "[person:name='alice'] AND [person:name='zelda']",
+    "[person:name='alice'] AND [person:age=10]",
+    "[person:name='alice'] FOLLOWEDBY [person:age=10]",
+    "[person:name='mary'] OR [person:name='zelda']",
+    "[person:age > 70] OR [person:name > 'zelda'] AND [person:name MATCHES '^...?$']",
+    "[person:name='bob'] FOLLOWEDBY [person:age<15]",
+    "[person:age > 20] OR [person:name > 'zelda'] FOLLOWEDBY [person:age < 0]",
+    "([person:age > 20] OR [person:name > 'zelda']) AND [person:age < 0]",
+    "[person:name='carol'] FOLLOWEDBY [person:name < 'elizabeth'] AND [person:age < 15]"
 ])
 def test_observation_ops_nomatch(pattern):
     assert not match(pattern, _observations)

--- a/stix2matcher/test/test_references.py
+++ b/stix2matcher/test/test_references.py
@@ -30,8 +30,8 @@ _observations = [
 
 @pytest.mark.parametrize("pattern", [
     "[person:knows_ref.name = 'bob']",
-    "[person:knows_refs[*].name = 'alice' or person:knows_ref.name = 'darlene']",
-    "[person:knows_refs[*].name = 'carol' and person:knows_refs[*].name = 'bob']",
+    "[person:knows_refs[*].name = 'alice' OR person:knows_ref.name = 'darlene']",
+    "[person:knows_refs[*].name = 'carol' AND person:knows_refs[*].name = 'bob']",
     "[person:knows_refs[*].knows_refs[*].name = 'alice']"
 ])
 def test_references_match(pattern):
@@ -40,8 +40,8 @@ def test_references_match(pattern):
 
 @pytest.mark.parametrize("pattern", [
     "[person:knows_ref.name = 'erin']",
-    "[person:knows_refs[*].name = 'alice' and person:knows_ref.name = 'darlene']",
-    "[person:knows_refs[*].name = 'erin' or person:knows_refs[*].name = 'darlene']"
+    "[person:knows_refs[*].name = 'alice' AND person:knows_ref.name = 'darlene']",
+    "[person:knows_refs[*].name = 'erin' OR person:knows_refs[*].name = 'darlene']"
 ])
 def test_references_nomatch(pattern):
     assert not match(pattern, _observations)

--- a/stix2matcher/test/test_temporal_qualifiers.py
+++ b/stix2matcher/test/test_temporal_qualifiers.py
@@ -1,7 +1,7 @@
 from stix2patterns.pattern import ParseException
 
 # I'll specially test some critical internal time-interval related code,
-# since it's easier to test it separately than create lots of SDOs and
+# since it's easier to test it separately than create lots of SDOs AND
 # patterns.
 import pytest
 from stix2matcher.matcher import (_OVERLAP, _OVERLAP_NONE,
@@ -51,20 +51,20 @@ _observations = [
 
 @pytest.mark.parametrize("pattern", [
     # WITHIN tests
-    "[person:name = 'bob'] within 1 seconds",
-    "[person:name = 'bob'] within .0001 seconds",
-    "[person:name = 'alice'] and [person:name < 'carol'] within 1 seconds",
-    "([person:name = 'alice'] and [person:name < 'carol']) within 5 seconds",
-    "([person:name = 'alice'] and [person:name < 'carol']) within 6 seconds",
-    "([person:name = 'alice'] or [person:name = 'darlene']) within 1 seconds",
+    "[person:name = 'bob'] WITHIN 1 SECONDS",
+    "[person:name = 'bob'] WITHIN .0001 SECONDS",
+    "[person:name = 'alice'] AND [person:name < 'carol'] WITHIN 1 SECONDS",
+    "([person:name = 'alice'] AND [person:name < 'carol']) WITHIN 5 SECONDS",
+    "([person:name = 'alice'] AND [person:name < 'carol']) WITHIN 6 SECONDS",
+    "([person:name = 'alice'] OR [person:name = 'darlene']) WITHIN 1 SECONDS",
 
     # START/STOP tests
-    "[person:name = 'bob'] start '1994-11-29T13:37:57Z' stop '1994-11-29T13:37:58Z'",
-    "[person:name like 'a%'] and [person:name = 'bob'] start '1994-11-29T13:37:57Z' stop '1994-11-29T13:37:58Z'",
-    "([person:name like 'a%'] and [person:name = 'bob']) start '1994-11-29T13:37:50Z' stop '1994-11-29T13:37:58Z'",
-    "[person:name = 'alice'] or [person:name = 'darlene'] start '1994-11-29T13:37:57Z' stop '1994-11-29T13:37:58Z'",
-    "([person:name = 'alice'] or [person:name = 'darlene']) start '1994-11-29T13:37:52Z' stop '1994-11-29T13:37:58Z'",
-    "[person:name matches ''] repeats 2 times start '1994-11-29T13:37:50Z' stop '1994-11-29T13:37:58Z'",
+    "[person:name = 'bob'] START '1994-11-29T13:37:57Z' STOP '1994-11-29T13:37:58Z'",
+    "[person:name LIKE 'a%'] AND [person:name = 'bob'] START '1994-11-29T13:37:57Z' STOP '1994-11-29T13:37:58Z'",
+    "([person:name LIKE 'a%'] AND [person:name = 'bob']) START '1994-11-29T13:37:50Z' STOP '1994-11-29T13:37:58Z'",
+    "[person:name = 'alice'] OR [person:name = 'darlene'] START '1994-11-29T13:37:57Z' STOP '1994-11-29T13:37:58Z'",
+    "([person:name = 'alice'] OR [person:name = 'darlene']) START '1994-11-29T13:37:52Z' STOP '1994-11-29T13:37:58Z'",
+    "[person:name MATCHES ''] REPEATS 2 TIMES START '1994-11-29T13:37:50Z' STOP '1994-11-29T13:37:58Z'",
 ])
 def test_temp_qual_match(pattern):
     assert match(pattern, _observations)
@@ -72,19 +72,19 @@ def test_temp_qual_match(pattern):
 
 @pytest.mark.parametrize("pattern", [
     # WITHIN tests
-    "([person:name = 'alice'] and [person:name < 'carol']) within 4 seconds",
-    "([person:name = 'alice'] and [person:name < 'carol']) within 4.9999 seconds",
-    "[person:name = 'elizabeth'] within 10 seconds",
-    "([person:name < 'alice'] or [person:name = 'darlene']) within 10 seconds",
+    "([person:name = 'alice'] AND [person:name < 'carol']) WITHIN 4 SECONDS",
+    "([person:name = 'alice'] AND [person:name < 'carol']) WITHIN 4.9999 SECONDS",
+    "[person:name = 'elizabeth'] WITHIN 10 SECONDS",
+    "([person:name < 'alice'] OR [person:name = 'darlene']) WITHIN 10 SECONDS",
 
     # START/STOP tests
-    "[person:name = 'bob'] start '1994-11-29T13:37:58Z' stop '1994-11-29T13:37:58Z'",
-    "[person:name = 'bob'] start '1994-11-29T13:37:59Z' stop '1994-11-29T13:37:58Z'",
-    "[person:name = 'bob'] start '1994-11-29T13:37:58Z' stop '1994-11-29T13:37:59Z'",
-    "([person:name like 'a%'] and [person:name = 'bob']) start '1994-11-29T13:37:50Z' stop '1994-11-29T13:37:57Z'",
-    "([person:name like 'z%'] or [person:name = 'darlene']) start '1994-11-29T13:37:50Z' stop '1994-11-29T13:37:57Z'",
-    "[person:name matches ''] repeats 3 times start '1994-11-29T13:37:50Z' stop '1994-11-29T13:37:58Z'",
-    "[person:name not like 'foo'] start '1994-11-29T13:37:50Z' stop '1994-11-29T13:37:57Z' repeats 3 times",
+    "[person:name = 'bob'] START '1994-11-29T13:37:58Z' STOP '1994-11-29T13:37:58Z'",
+    "[person:name = 'bob'] START '1994-11-29T13:37:59Z' STOP '1994-11-29T13:37:58Z'",
+    "[person:name = 'bob'] START '1994-11-29T13:37:58Z' STOP '1994-11-29T13:37:59Z'",
+    "([person:name LIKE 'a%'] AND [person:name = 'bob']) START '1994-11-29T13:37:50Z' STOP '1994-11-29T13:37:57Z'",
+    "([person:name LIKE 'z%'] OR [person:name = 'darlene']) START '1994-11-29T13:37:50Z' STOP '1994-11-29T13:37:57Z'",
+    "[person:name MATCHES ''] REPEATS 3 TIMES START '1994-11-29T13:37:50Z' STOP '1994-11-29T13:37:58Z'",
+    "[person:name NOT LIKE 'foo'] START '1994-11-29T13:37:50Z' STOP '1994-11-29T13:37:57Z' REPEATS 3 TIMES",
 ])
 def test_temp_qual_nomatch(pattern):
     assert not match(pattern, _observations)
@@ -92,13 +92,13 @@ def test_temp_qual_nomatch(pattern):
 
 @pytest.mark.parametrize("pattern", [
     # WITHIN tests
-    "[person:name = 'alice'] within 0 seconds",
+    "[person:name = 'alice'] WITHIN 0 SECONDS",
 
     # START/STOP tests
-    "[person:name = 'hannah'] start '1994-11-29t13:37:58Z' stop '1994-11-29T13:37:58Z'",
-    "[person:name = 'hannah'] start '1994-11-29T13:37:58Z' stop '1994-11-29T13:37:58z'",
-    "[person:name = 'hannah'] start '1994-11-29t13:37:58Z' stop '1994-11-29T13:37:58'",
-    "[person:name = 'hannah'] start '1994-11-29T13:37Z' stop '1994-11-29T13:37:58Z'",
+    "[person:name = 'hannah'] START '1994-11-29t13:37:58Z' STOP '1994-11-29T13:37:58Z'",
+    "[person:name = 'hannah'] START '1994-11-29T13:37:58Z' STOP '1994-11-29T13:37:58z'",
+    "[person:name = 'hannah'] START '1994-11-29t13:37:58Z' STOP '1994-11-29T13:37:58'",
+    "[person:name = 'hannah'] START '1994-11-29T13:37Z' STOP '1994-11-29T13:37:58Z'",
 ])
 def test_temp_qual_error_match(pattern):
     with pytest.raises(MatcherException):
@@ -107,11 +107,11 @@ def test_temp_qual_error_match(pattern):
 
 @pytest.mark.parametrize("pattern", [
     # WITHIN tests
-    "[person:name = 'alice'] within 1 second",
-    "[person:name = 'alice'] within -123.367 seconds",
+    "[person:name = 'alice'] WITHIN 1 second",
+    "[person:name = 'alice'] WITHIN -123.367 SECONDS",
 
     # START/STOP tests
-    "[person:name = 'hannah'] start '1994-11-29T13:37:58Z'",
+    "[person:name = 'hannah'] START '1994-11-29T13:37:58Z'",
 ])
 def test_temp_qual_error_parse(pattern):
     with pytest.raises(ParseException):
@@ -201,8 +201,8 @@ def test_within_match(interval1, interval2, duration):
     _observations[1]["first_observed"] = interval2[0]
     _observations[1]["last_observed"] = interval2[1]
 
-    pattern = "([person:name='alice'] and [person:name='bob']) " \
-              "within {0} seconds".format(duration)
+    pattern = "([person:name='alice'] AND [person:name='bob']) " \
+              "WITHIN {0} SECONDS".format(duration)
     assert match(pattern, _observations)
 
 
@@ -219,6 +219,6 @@ def test_within_nomatch(interval1, interval2, duration):
     _observations[1]["first_observed"] = interval2[0]
     _observations[1]["last_observed"] = interval2[1]
 
-    pattern = "([person:name='alice'] and [person:name='bob']) " \
-              "within {0} seconds".format(duration)
+    pattern = "([person:name='alice'] AND [person:name='bob']) " \
+              "WITHIN {0} SECONDS".format(duration)
     assert not match(pattern, _observations)

--- a/stix2matcher/test/test_temporal_qualifiers.py
+++ b/stix2matcher/test/test_temporal_qualifiers.py
@@ -93,7 +93,6 @@ def test_temp_qual_nomatch(pattern):
 @pytest.mark.parametrize("pattern", [
     # WITHIN tests
     "[person:name = 'alice'] within 0 seconds",
-    "[person:name = 'alice'] within -123.367 seconds",
 
     # START/STOP tests
     "[person:name = 'hannah'] start '1994-11-29t13:37:58Z' stop '1994-11-29T13:37:58Z'",
@@ -109,6 +108,7 @@ def test_temp_qual_error_match(pattern):
 @pytest.mark.parametrize("pattern", [
     # WITHIN tests
     "[person:name = 'alice'] within 1 second",
+    "[person:name = 'alice'] within -123.367 seconds",
 
     # START/STOP tests
     "[person:name = 'hannah'] start '1994-11-29T13:37:58Z'",

--- a/stix2matcher/test/test_timestamps.py
+++ b/stix2matcher/test/test_timestamps.py
@@ -34,8 +34,8 @@ _observations = [
     "[event:good_ts > t'1974-11-05T05:31:11Z']",
     "[event:good_ts < t'3012-08-17T17:43:55Z']",
     "[event:good_ts_frac = t'2010-05-21T13:21:43.1234Z']",
-    "[event:good_ts in (t'1953-11-26T14:25:33Z', t'2010-05-21T13:21:43Z', t'2000-06-17T17:25:51.44Z')]",
-    "[event:good_ts not in (t'1953-11-26T14:25:33Z', t'1985-07-25T20:27:52Z', t'2000-06-17T17:25:51.44Z')]"
+    "[event:good_ts IN (t'1953-11-26T14:25:33Z', t'2010-05-21T13:21:43Z', t'2000-06-17T17:25:51.44Z')]",
+    "[event:good_ts NOT IN (t'1953-11-26T14:25:33Z', t'1985-07-25T20:27:52Z', t'2000-06-17T17:25:51.44Z')]"
 ])
 def test_ts_match(pattern):
     assert match(pattern, _observations)
@@ -48,8 +48,8 @@ def test_ts_match(pattern):
     "[event:good_ts <= t'1974-11-05T05:31:11Z']",
     "[event:good_ts >= t'3012-08-17T17:43:55Z']",
     "[event:good_ts_frac != t'2010-05-21T13:21:43.1234Z']",
-    "[event:good_ts not in (t'1953-11-26T14:25:33Z', t'2010-05-21T13:21:43Z', t'2000-06-17T17:25:51.44Z')]",
-    "[event:good_ts in (t'1953-11-26T14:25:33Z', t'1985-07-25T20:27:52Z', t'2000-06-17T17:25:51.44Z')]"
+    "[event:good_ts NOT IN (t'1953-11-26T14:25:33Z', t'2010-05-21T13:21:43Z', t'2000-06-17T17:25:51.44Z')]",
+    "[event:good_ts IN (t'1953-11-26T14:25:33Z', t'1985-07-25T20:27:52Z', t'2000-06-17T17:25:51.44Z')]"
 ])
 def test_ts_nomatch(pattern):
     assert not match(pattern, _observations)

--- a/stix2matcher/test/test_timestamps.py
+++ b/stix2matcher/test/test_timestamps.py
@@ -61,20 +61,10 @@ def test_ts_nomatch(pattern):
     "[event:good_ts = t'2010-05-21t13:21:43Z']",
     "[event:good_ts = t'2010/05/21T13:21:43Z']",
     "[event:good_ts = t'2010-05-21T13:21Z']",
+    "[event:good_ts = t'2010-05-21T13:21:99Z']"
 ])
 def test_ts_pattern_error_parse(pattern):
     with pytest.raises(ParseException):
-        match(pattern, _observations)
-
-
-@pytest.mark.parametrize("pattern", [
-    # This one causes MatcherException because the parser doesn't
-    # validate the timestamp content, only its syntax, so the error
-    # isn't caught until match time.
-    "[event:good_ts = t'2010-05-21T13:21:99Z']",
-])
-def test_ts_pattern_error_match(pattern):
-    with pytest.raises(MatcherException):
         match(pattern, _observations)
 
 

--- a/stix2matcher/test/test_unicode_normalization.py
+++ b/stix2matcher/test/test_unicode_normalization.py
@@ -51,7 +51,7 @@ def _mismatched_kv_pairs():
 
 
 @pytest.mark.parametrize("pattern", [
-    u"[test:ddots.{} like '{}']".format(k, v)
+    u"[test:ddots.{} LIKE '{}']".format(k, v)
     for k, v in _all_kv_pairs()
 ])
 def test_unicode_normalization_like_match(pattern):
@@ -59,7 +59,7 @@ def test_unicode_normalization_like_match(pattern):
 
 
 @pytest.mark.parametrize("pattern", [
-    u"[test:ddots.{} matches '^{}$']".format(k, v)
+    u"[test:ddots.{} MATCHES '^{}$']".format(k, v)
     for k, v in _all_kv_pairs()
 ])
 def test_unicode_normalization_regex_match(pattern):
@@ -99,7 +99,7 @@ def test_unicode_normalization_eq_nomatch(pattern):
 
 
 @pytest.mark.parametrize("pattern", [
-    u"[test:ddots.{} in ('{}')]".format(k, v)
+    u"[test:ddots.{} IN ('{}')]".format(k, v)
     for k, v in _matched_kv_pairs()
 ])
 def test_unicode_normalization_set_match(pattern):
@@ -107,7 +107,7 @@ def test_unicode_normalization_set_match(pattern):
 
 
 @pytest.mark.parametrize("pattern", [
-    u"[test:ddots.{} in ('{}')]".format(k, v)
+    u"[test:ddots.{} IN ('{}')]".format(k, v)
     for k, v in _mismatched_kv_pairs()
 ])
 def test_unicode_normalization_set_nomatch(pattern):


### PR DESCRIPTION
The changes removed the IntLiteral token and replaced it with IntPosLiteral and IntNegLiteral, and similarly for FloatLiteral.  I think these matcher fixes were really necessitated by the aforementioned grammar changes which happened several months ago, not the changes I just recently made (which only changed the definitions of existing tokens and didn't introduce any new ones).

Also made it so negative list indices don't cause a matcher error.  The spec doesn't state that there should be an error, just that the comparison should eval to false.  See STIX 2.0 spec part 5 section 5.2.  Maybe there should be some additional tests which focus on object paths... I don't think there is a test which covers things like out-of-range list indices.

Had to fix some tests, since some syntax checking was moved into the lexer.  Some issues which previously generated matcher errors, now generate parse errors.

The tests will not pass until an updated pattern-validator is released, because they rely on the updated lexer and parser with the new "Pos"/"Neg" tokens.