### PR TITLE
Matching re-occuring value within patterns

### DIFF
--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -1772,10 +1772,14 @@ class MatchListener(STIXPatternListener):
         # store which matching group (defined in interobs pattern) matched on what string for each Observable
         for obs_id, container in obs_values.items():
             value = container[list(container.keys())[0]][0]
-            if not isinstance(value, (str, unicode)):
-                continue
-            if isinstance(value, unicode):
-                value = value.encode('utf-8')
+            if sys.version_info < (3, 0, 0):
+                if not isinstance(value, (str, unicode)):
+                    continue
+                if isinstance(value, unicode):
+                    value = value.encode('utf-8')
+            else:
+                if not isinstance(value, str):
+                    continue
             for match in compiled_re.finditer(value):
                 for group, val in match.groupdict().items():
                     grp_dict = self.interobs_group_matches.get(group, {})

--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -1771,7 +1771,11 @@ class MatchListener(STIXPatternListener):
 
         # store which matching group (defined in interobs pattern) matched on what string for each Observable
         for obs_id, container in obs_values.items():
-            value = str(container[list(container.keys())[0]][0])
+            value = container[list(container.keys())[0]][0]
+            if not isinstance(value, (str, unicode)):
+                continue
+            if isinstance(value, unicode):
+                value = value.encode('utf-8')
             for match in compiled_re.finditer(value):
                 for group, val in match.groupdict().items():
                     grp_dict = self.interobs_group_matches.get(group, {})

--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -1772,14 +1772,11 @@ class MatchListener(STIXPatternListener):
         # store which matching group (defined in interobs pattern) matched on what string for each Observable
         for obs_id, container in obs_values.items():
             value = container[list(container.keys())[0]][0]
-            if sys.version_info < (3, 0, 0):
-                if not isinstance(value, (str, unicode)):
-                    continue
-                if isinstance(value, unicode):
+            if not isinstance(value, six.string_types):
+                continue
+            if sys.version_info.major < 3:
+                if isinstance(value, unicode):  # noqa: F821
                     value = value.encode('utf-8')
-            else:
-                if not isinstance(value, str):
-                    continue
             for match in compiled_re.finditer(value):
                 for group, val in match.groupdict().items():
                     grp_dict = self.interobs_group_matches.get(group, {})

--- a/stix2matcher/test/test_inter_observable_expr.py
+++ b/stix2matcher/test/test_inter_observable_expr.py
@@ -1,0 +1,70 @@
+import pytest
+from stix2matcher.matcher import match
+
+_observations = [
+    {
+        "type": "observed-data",
+        "first_observed": "2004-10-11T21:44:58Z",
+        "last_observed": "2004-10-11T21:44:58Z",
+        "number_observed": 1,
+        "objects": {
+            "0": {
+                "type": u"person",
+                "name": u"alice",
+                "place": u"earth"
+            }
+        }
+    },
+    {
+        "type": "observed-data",
+        "first_observed": "2008-05-09T01:21:58.6Z",
+        "last_observed": "2008-05-09T01:21:58.6Z",
+        "number_observed": 1,
+        "objects": {
+            "0": {
+                "type": u"person",
+                "name": u"malice",
+                "place": u"moontown"
+            }
+        }
+    },
+    {
+        "type": "observed-data",
+        "first_observed": "2006-11-03T07:42:18.96Z",
+        "last_observed": "2006-11-03T07:42:18.96Z",
+        "number_observed": 1,
+        "objects": {
+            "0": {
+                "type": u"person",
+                "name": u"bob",
+                "city_ref": u"1"
+            },
+            "1": {
+                "type": u"city",
+                "name": u"bobtown"
+            }
+        }
+    }
+]
+
+
+@pytest.mark.parametrize("pattern", [
+    "[person:name MATCHES '(?P<v1>[a-z]+)'] AND [person:name MATCHES 'm(?P<v1>[a-z]+)']",   # same value across observables (name of person B is the same as person A, but with a leading 'm')
+    "[person:name MATCHES '(?P<v2>[a-z]+)' AND person:city_ref.name MATCHES '(?P<v2>[a-z]+)town']", # same value across properties (home of person is its name plus 'town'-suffix)
+    "[person:name MATCHES '(?P<v3>[a-z]).(?P=v3)']", # same value within a property (first letter of name is the same as third letter)
+    # the following three patterns are the equivalent ones to the negative assertions below, only without interobs patterns
+    "[person:name MATCHES '[a-z]+'] AND [person:name MATCHES '[a-z]+']",
+    "[person:name MATCHES '[a-z]+' AND person:city_ref.name MATCHES '[a-z]+']",
+    "[person:name MATCHES '[a-z][a-z]']",
+])
+def test_observation_ops_match(pattern):
+    assert match(pattern, _observations)
+
+
+@pytest.mark.parametrize("pattern", [
+    "[person:name MATCHES '(?P<v1>[a-z]+)'] AND [person:name MATCHES '(?P<v1>[a-z]+)']", # same value across observables (two persons with the same name)
+    "[person:name MATCHES '(?P<v2>[a-z]+)' AND person:city_ref.name MATCHES '(?P<v2>[a-z]+)']", # same value across properties (home of person is the same as name)
+    "[person:name MATCHES '(?P<v3>[a-z])(?P=v3)']", # same value within a property (first letter of name is the same as second letter)
+])
+def test_observation_ops_nomatch(pattern):
+    assert not match(pattern, _observations)

--- a/stix2matcher/test/test_inter_observable_expr.py
+++ b/stix2matcher/test/test_inter_observable_expr.py
@@ -49,22 +49,18 @@ _observations = [
 
 
 @pytest.mark.parametrize("pattern", [
-    "[person:name MATCHES '(?P<v1>[a-z]+)'] AND [person:name MATCHES 'm(?P<v1>[a-z]+)']",   # same value across observables (name of person B is the same as person A, but with a leading 'm')
-    "[person:name MATCHES '(?P<v2>[a-z]+)' AND person:city_ref.name MATCHES '(?P<v2>[a-z]+)town']", # same value across properties (home of person is its name plus 'town'-suffix)
-    "[person:name MATCHES '(?P<v3>[a-z]).(?P=v3)']", # same value within a property (first letter of name is the same as third letter)
-    # the following three patterns are the equivalent ones to the negative assertions below, only without interobs patterns
-    "[person:name MATCHES '[a-z]+'] AND [person:name MATCHES '[a-z]+']",
-    "[person:name MATCHES '[a-z]+' AND person:city_ref.name MATCHES '[a-z]+']",
-    "[person:name MATCHES '[a-z][a-z]']",
+    "[person:name MATCHES '(?P<v1>[a-z]+)'] AND [person:name MATCHES 'm(?P<v1>[a-z]+)']",  # same value across observables (name of person B is the same as person A, but with a leading 'm')
+    "[person:name MATCHES '(?P<v2>[a-z]+)' AND person:city_ref.name MATCHES '(?P<v2>[a-z]+)town']",  # same value across properties (home of person is its name plus 'town'-suffix)
+    "[person:name MATCHES '(?P<v3>[a-z]).(?P=v3)']",  # same value within a property (first letter of name is the same as third letter)
 ])
 def test_observation_ops_match(pattern):
     assert match(pattern, _observations)
 
 
 @pytest.mark.parametrize("pattern", [
-    "[person:name MATCHES '(?P<v1>[a-z]+)'] AND [person:name MATCHES '(?P<v1>[a-z]+)']", # same value across observables (two persons with the same name)
-    "[person:name MATCHES '(?P<v2>[a-z]+)' AND person:city_ref.name MATCHES '(?P<v2>[a-z]+)']", # same value across properties (home of person is the same as name)
-    "[person:name MATCHES '(?P<v3>[a-z])(?P=v3)']", # same value within a property (first letter of name is the same as second letter)
+    "[person:name MATCHES '(?P<v1>[a-z]+)'] AND [person:name MATCHES '(?P<v1>[a-z]+)']",  # same value across observables (two persons with the same name)
+    "[person:name MATCHES '(?P<v2>[a-z]+)' AND person:city_ref.name MATCHES '(?P<v2>[a-z]+)']",  # same value across properties (home of person is the same as name)
+    "[person:name MATCHES '(?P<v3>[a-z])(?P=v3)']",  # same value within a property (first letter of name is the same as second letter)
 ])
 def test_observation_ops_nomatch(pattern):
     assert not match(pattern, _observations)

--- a/stix2matcher/test/test_inter_observable_expr.py
+++ b/stix2matcher/test/test_inter_observable_expr.py
@@ -49,18 +49,24 @@ _observations = [
 
 
 @pytest.mark.parametrize("pattern", [
-    "[person:name MATCHES '(?P<v1>[a-z]+)'] AND [person:name MATCHES 'm(?P<v1>[a-z]+)']",  # same value across observables (name of person B is the same as person A, but with a leading 'm')
-    "[person:name MATCHES '(?P<v2>[a-z]+)' AND person:city_ref.name MATCHES '(?P<v2>[a-z]+)town']",  # same value across properties (home of person is its name plus 'town'-suffix)
-    "[person:name MATCHES '(?P<v3>[a-z]).(?P=v3)']",  # same value within a property (first letter of name is the same as third letter)
+    # same value across observables (name of person B is the same as person A, but with a leading 'm')
+    "[person:name MATCHES '(?P<v1>[a-z]+)'] AND [person:name MATCHES 'm(?P<v1>[a-z]+)']",
+    # same value across properties (home of person is its name plus 'town'-suffix)
+    "[person:name MATCHES '(?P<v2>[a-z]+)' AND person:city_ref.name MATCHES '(?P<v2>[a-z]+)town']",
+    # same value within a property (first letter of name is the same as third letter)
+    "[person:name MATCHES '(?P<v3>[a-z]).(?P=v3)']",
 ])
 def test_observation_ops_match(pattern):
     assert match(pattern, _observations)
 
 
 @pytest.mark.parametrize("pattern", [
-    "[person:name MATCHES '(?P<v1>[a-z]+)'] AND [person:name MATCHES '(?P<v1>[a-z]+)']",  # same value across observables (two persons with the same name)
-    "[person:name MATCHES '(?P<v2>[a-z]+)' AND person:city_ref.name MATCHES '(?P<v2>[a-z]+)']",  # same value across properties (home of person is the same as name)
-    "[person:name MATCHES '(?P<v3>[a-z])(?P=v3)']",  # same value within a property (first letter of name is the same as second letter)
+    # same value across observables (two persons with the same name)
+    "[person:name MATCHES '(?P<v1>[a-z]+)'] AND [person:name MATCHES '(?P<v1>[a-z]+)']",
+    # same value across properties (home of person is the same as name)
+    "[person:name MATCHES '(?P<v2>[a-z]+)' AND person:city_ref.name MATCHES '(?P<v2>[a-z]+)']",
+    # same value within a property (first letter of name is the same as second letter)
+    "[person:name MATCHES '(?P<v3>[a-z])(?P=v3)']",
 ])
 def test_observation_ops_nomatch(pattern):
     assert not match(pattern, _observations)


### PR DESCRIPTION
We propose a solution to evaluate our so called **inter-observable patterns** described in Issue #57.
I will try to describe what our code changes do:

- [*1772-1782*]: Since variables to describe inter-observables can only be defined within regular expressions, we adjusted the `exitPropTestRegex`-function. Whenever a regex containing a variable is successfully matched against an Observable object, we store the variable name, Observable ID and actual value the variable matched on in a nested dictionary (`interobs_group_matches`). Example: we have the pattern `[file:name MATCHES '(?P<var>[a-z]{3})]`, a File-Observable with filename 'foo' and one with filename 'bar'. `interobs_group_matches` will look like this: `{'var': {0: ['foo'], 1: ['bar']}}`.
- [*2147-2151*]: We need to run our checks on all found bindings. Up to this point the actual matching process is unaltered and only those bindings are considered further which fulfill a pattern ignoring any variables.
- [*2190-2209*]: Check if any variables were matched, i.e. values exists within the dictionary. If not, return SDOs for bindings (original behaviour). If there are values, iterate over all found bindings. For each binding, only consider the relevant SDOs, i.e. create a copy of `interobs_group_matches` and remove all values of  irrelevant SDOs. Then run the checks on this copy. If a check returns `false`, remove the current binding from `found_bindings` -- it does not fulfill the inter-observable pattern.
- [*2165-2189*]: The actual checks. If only one SDO is present, it is considered an invalid match if a variable matched on more than one unique value. When multiple SDOs are present, we look for intersections between the values for each variable; if no intersection exist, the variable did not match on the same values for these SDOs.

Our changes to the code are as transparent as possible to the original functionality of the matcher. We also added a small test to evaluate the functionality of inter-observable patterns.