### PR TITLE
Remove direct dependency declaration on antlr4-python3-runtime

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,6 @@ setup(
     packages=find_packages(),
     description='Match STIX content against STIX patterns',
     install_requires=[
-        'antlr4-python2-runtime==4.7 ; python_version < "3"',
-        'antlr4-python3-runtime==4.7 ; python_version >= "3"',
         'python-dateutil',
         'six',
         'stix2-patterns>=1.0.0',


### PR DESCRIPTION
Fixes #60 .

Remove direct dependency declaration on antlr4-python[23]-runtime from setup.py.  This should cause pattern-matcher to use the version of ANTLR which came with the pattern-validator, whatever that was.  So in the future, version conflicts between these two libraries will be impossible.