### PR TITLE
Adding Python 3.8 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-matrix:
-  include:
-    - python: 3.7 # https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905
-      dist: xenial
-      sudo: true
+  - "3.7"
+  - "3.8"
 install:
   - pip install -U pip setuptools
   - pip install tox-travis

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,style,isort-check
+envlist = py27,py34,py35,py36,py37,py38,style,isort-check
 
 [testenv]
 deps =
@@ -39,3 +39,4 @@ python =
   3.5: py35, style
   3.6: py36, style, isort-check
   3.7: py37, style
+  3.8: py38, style


### PR DESCRIPTION
Python 3.8 has been released in October 2019 and it is expected that security updates until approximately October 2024.

See [PEP 569 -- Python 3.8 Release Schedule ](https://www.python.org/dev/peps/pep-0569/) 