### PR TITLE
Use generators instead of lists to limit memory usage and speed up `match`

### DIFF
--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -960,6 +960,9 @@ class MatchListener(STIXPatternListener):
     many bindings, rather than just the first one found, as might
     be the case with a backtracking algorithm.
 
+    Actually, through the use of generators to represent sets of bindings an
+    implicit form of backtracking limits the memory usage.
+
     I made the conscious decision to skip some bindings in one particular case,
     to improve scalability (see exitObservationExpressionOr()) without
     affecting correctness.

--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -870,21 +870,19 @@ def _filtered_combinations_from_list(value_list, combo_size, pre_filter=None, po
 
     if combo_size < 1:
         raise ValueError(u"combo_size must be >= 1")
-    elif combo_size > len(value_list):
-        # Not enough values to make any combo
-        yield from ()
     elif combo_size == 1:
         # Each value is its own combo
         yield from (
             (value,) for value in value_list
             if post_filter is None or post_filter(value)
         )
-    else:
+        return
 
+    for i in range(len(value_list) + 1 - combo_size):
         filtered_values = [
             candidate
-            for candidate in value_list[1:]
-            if pre_filter is None or pre_filter(value_list[0], candidate)
+            for candidate in value_list[i + 1:]
+            if pre_filter is None or pre_filter(value_list[i], candidate)
         ]
 
         sub_combos = _filtered_combinations_from_list(
@@ -895,16 +893,9 @@ def _filtered_combinations_from_list(value_list, combo_size, pre_filter=None, po
         )
 
         yield from (
-            (value_list[0],) + sub_combo
+            (value_list[i],) + sub_combo
             for sub_combo in sub_combos
-            if post_filter is None or post_filter(value_list[0], *sub_combo)
-        )
-
-        yield from _filtered_combinations_from_list(
-            value_list[1:],
-            combo_size,
-            pre_filter,
-            post_filter,
+            if post_filter is None or post_filter(value_list[i], *sub_combo)
         )
 
 

--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -871,8 +871,11 @@ def _filtered_combinations_from_list(value_list, combo_size, filter_pred=None):
         )
     else:
 
-        sub_combos = _filtered_combinations_from_list(value_list[1:], combo_size - 1,
-                                            filter_pred)
+        sub_combos = _filtered_combinations_from_list(
+            value_list[1:],
+            combo_size - 1,
+            filter_pred,
+        )
 
         yield from (
             (value_list[0],) + sub_combo
@@ -1149,7 +1152,6 @@ class MatchListener(STIXPatternListener):
                     _lhs_cache.append(_next_lhs_binding)
                     _next_lhs_binding = next(lhs_bindings, None)
 
-
         self.__push(joined_bindings(), debug_label)
 
     def __followed_by_left_join(self, lhs_binding, rhs_bindings):
@@ -1194,7 +1196,7 @@ class MatchListener(STIXPatternListener):
         )
 
     def __earliest_last_timestamp(self, binding):
-        return  min(
+        return min(
             self.__time_intervals[obs_id][1]
             for obs_id in binding
             if obs_id is not None

--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -1448,9 +1448,9 @@ class MatchListener(STIXPatternListener):
                 duration
             )
 
-        filtered_bindings = filter(check_within, bindings)
+        filtered_bindings = (binding for binding in bindings if check_within(binding))
 
-        self.__push(iter(filtered_bindings), debug_label)
+        self.__push(filtered_bindings, debug_label)
 
     def exitObservationExpressionStartStop(self, ctx):
         """
@@ -1484,11 +1484,11 @@ class MatchListener(STIXPatternListener):
         # satisfy, since a value can't be both >= and < the same number.
         # And of course it's impossible if start > stop.
         if start_time < stop_time:
-            filtered_bindings = filter(check_within, bindings)
+            filtered_bindings = (binding for binding in bindings if check_within(binding))
         else:
-            filtered_bindings = ()
+            filtered_bindings = iter(())
 
-        self.__push(iter(filtered_bindings), debug_label)
+        self.__push(filtered_bindings, debug_label)
 
     def exitStartStopQualifier(self, ctx):
         """

--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -1482,8 +1482,6 @@ class MatchListener(STIXPatternListener):
                     for obs_id in binding if obs_id is not None
                 )
 
-        filtered_bindings = filter(check_within, bindings)
-
         # If start and stop are equal, the constraint is impossible to
         # satisfy, since a value can't be both >= and < the same number.
         # And of course it's impossible if start > stop.
@@ -1492,7 +1490,7 @@ class MatchListener(STIXPatternListener):
         else:
             filtered_bindings = iter(())
 
-        self.__push(iter(filtered_bindings), debug_label)
+        self.__push(filtered_bindings, debug_label)
 
     def exitStartStopQualifier(self, ctx):
         """

--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -1473,7 +1473,7 @@ class MatchListener(STIXPatternListener):
         start_time, stop_time = self.__pop(debug_label)
         bindings = self.__pop(debug_label)
 
-        def check_within(binding):
+        def check_overlap(binding):
             return all(
                     _overlap(start_time, stop_time, *self.__time_intervals[obs_id])
                     in (_OVERLAP, _OVERLAP_TOUCH_OUTER)
@@ -1484,7 +1484,7 @@ class MatchListener(STIXPatternListener):
         # satisfy, since a value can't be both >= and < the same number.
         # And of course it's impossible if start > stop.
         if start_time < stop_time:
-            filtered_bindings = (binding for binding in bindings if check_within(binding))
+            filtered_bindings = (binding for binding in bindings if check_overlap(binding))
         else:
             filtered_bindings = iter(())
 

--- a/stix2matcher/test/test_complex.py
+++ b/stix2matcher/test/test_complex.py
@@ -95,6 +95,7 @@ for i in range(20):
     "[person:age < 20] REPEATS 10 TIMES AND [person:age < 20]",
     "[person:age < 20] REPEATS 10 TIMES OR [person:age < 20]",
     "[person:age < 20] REPEATS 10 TIMES FOLLOWEDBY [person:age < 20]",
+    "[person:age < 20] REPEATS 5 TIMES REPEATS 2 TIMES",
     " AND ".join("[person:age < 20]" for _ in range(10)),
     " OR ".join("[person:age < 20]" for _ in range(10)),
 ])

--- a/stix2matcher/test/test_complex.py
+++ b/stix2matcher/test/test_complex.py
@@ -96,6 +96,7 @@ for i in range(20):
     "[person:age < 20] REPEATS 10 TIMES OR [person:age < 20]",
     "[person:age < 20] REPEATS 10 TIMES FOLLOWEDBY [person:age < 20]",
     "[person:age < 20] REPEATS 5 TIMES REPEATS 2 TIMES",
+    "[person:age < 20] REPEATS 2 TIMES REPEATS 5 TIMES",
     " AND ".join("[person:age < 20]" for _ in range(10)),
     " OR ".join("[person:age < 20]" for _ in range(10)),
 ])

--- a/stix2matcher/test/test_complex.py
+++ b/stix2matcher/test/test_complex.py
@@ -90,11 +90,19 @@ for i in range(20):
 
 @pytest.mark.parametrize("pattern", [
     "[person:age < 20] REPEATS 10 TIMES",
+    "[person:age < 20] REPEATS 10 TIMES WITHIN 10 SECONDS",
+    "[person:age < 20] REPEATS 10 TIMES START '2004-10-11T21:40:00Z' STOP '2004-10-11T21:50:00Z'",
+    "[person:age < 20] REPEATS 10 TIMES AND [person:age < 20]",
+    "[person:age < 20] REPEATS 10 TIMES OR [person:age < 20]",
+    "[person:age < 20] REPEATS 10 TIMES FOLLOWEDBY [person:age < 20]",
+    " AND ".join("[person:age < 20]" for _ in range(10)),
+    " OR ".join("[person:age < 20]" for _ in range(10)),
 ])
 def test_combinatorial_explosion_match(pattern):
     assert match(pattern, _observations_combinatorial_explosion)
 
 
+@pytest.mark.skip(reason="Too slow with the current implementation")
 @pytest.mark.parametrize("pattern", [
     "[person:age < 20] REPEATS 10 TIMES WITHIN 8 SECONDS",
 ])


### PR DESCRIPTION
Sets of bindings were represented as lists. As a consequence a `[...] REPEATS k` would generate all n choose k combinations before returning any binding (where n is the number of matches for [...]).

They are now represented as generators. It is now much faster to get a match.
We still have to try all n choose k combinations when there are no matches (or when one needs all matches), but in any case it consumes much less memory.
Generators can be seen as an implicit form of backtracking in this case.

I added some test cases to demonstrate the speed up.
As mentioned before the no match situation is still slow, that's why `test_combinatorial_explosion_nomatch` is marked `skip`.

The whole test suite (with added tests) takes less than 6s and uses less than 32MB after the patch.
Before the patch I had to kill it after 25 minutes since it was using more than 2GB and already failed on `[person:age < 20] REPEATS 5 TIMES REPEATS 2 TIMES` with `RecursionError: maximum recursion depth exceeded`