### PR TITLE
Improve _filtered_combinations_from_list stop condition

### DIFF
--- a/stix2matcher/test/test_complex.py
+++ b/stix2matcher/test/test_complex.py
@@ -99,6 +99,7 @@ for i in range(20):
     "[person:age < 20] REPEATS 2 TIMES REPEATS 5 TIMES",
     " AND ".join("[person:age < 20]" for _ in range(10)),
     " OR ".join("[person:age < 20]" for _ in range(10)),
+    "([person:age < 20] FOLLOWEDBY [person:age > 5]) REPEATS 10 TIMES",
 ])
 def test_combinatorial_explosion_match(pattern):
     assert match(pattern, _observations_combinatorial_explosion)

--- a/stix2matcher/test/test_complex.py
+++ b/stix2matcher/test/test_complex.py
@@ -81,7 +81,7 @@ for i in range(20):
                 "a0": {
                     "type": u"person",
                     "name": u"alice",
-                    "age": 10
+                    "age": i % 20
                 }
             }
         }


### PR DESCRIPTION
~This PR is built on top of #64, only commits after ba95106 are relevant.~ (EDIT: rebased after merge of #64)

_filtered_combinations is only used in the context of REPEATS with `_disjoint` as a filter.
Removing the filter argument, and forcing the use of _disjoint makes it possible to optimize the following stop condition (made implicit in #64): https://github.com/oasis-open/cti-pattern-matcher/blob/cd6aac7e6a49d3c61b22916bed5c341f65af3b36/stix2matcher/matcher.py#L823-L825

If we know that the combination must be disjoint, `len(values)` is a coarse over-approximation of the biggest combination one can build from `values`. By computing a better one, we can stop sooner.
As an example, suppose `values` is [(0,1), (1,2), (2,3), (3,0)] and `combo_size` is 3, `combo_size` is smaller than `len(values)` and we can't stop with the naive condition.
But we only have 4 numbers (0, 1, 2, 3), and `values` only contain tuples of size 2. Clearly we can not take more than two tuples without collision.

The added test was very slow even with #64, and is now reasonably fast.
