### PR TITLE
Adding Python 3.9 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 install:
   - pip install -U pip setuptools
   - pip install tox-travis

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,py38,style,isort-check
+envlist = py27,py34,py35,py36,py37,py38,py39,style,isort-check
 
 [testenv]
 deps =
@@ -39,3 +39,4 @@ python =
   3.6: py36, style, isort-check
   3.7: py37, style
   3.8: py38, style
+  3.9: py39, style


### PR DESCRIPTION
Python 3.9 has been released in October 2020 and it is expected that security updates will be released until approximately October 2025.

[See PEP 596 -- Python 3.9 Release Schedule](https://www.python.org/dev/peps/pep-0596/#id7)