### PR TITLE
Update matcher.py

### DIFF
--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -20,6 +20,7 @@ import antlr4.error.ErrorListener
 import antlr4.error.Errors
 import dateutil.relativedelta
 import dateutil.tz
+import dateutil.parser
 import six
 from stix2patterns.grammars.STIXPatternListener import STIXPatternListener
 from stix2patterns.grammars.STIXPatternParser import STIXPatternParser
@@ -481,7 +482,10 @@ def _str_to_datetime(timestamp_str, ignore_case=False):
     else:
         fmt = u"%Y-%m-%dT%H:%M:%SZ"
 
-    dt = datetime.datetime.strptime(timestamp_str, fmt)
+    try:
+        dt = datetime.datetime.strptime(timestamp_str, fmt)
+    except ValueError:
+        dt = dateutil.parser.parse(timestamp_str)
     dt = dt.replace(tzinfo=dateutil.tz.tzutc())
 
     return dt


### PR DESCRIPTION
strptime raises ValueError in case of nanoseconds precising (i.e. "2021-03-04T12:00:25.639380322Z"). dateutil.parser.parse doesn't preserve the nanoseconds it just chops off after 6 decimal places, but it at least won't break parsing in case of more than 6 decimal places.
strptime is ~7 time faster than dateutil.parser.parse, so it's better to use dateutil.parser.parse as a fallback