### PR TITLE
don't break on precision grater than microsecond

### DIFF
--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -478,6 +478,12 @@ def _str_to_datetime(timestamp_str, ignore_case=False):
     # Can't create a pattern with an optional part... so use two patterns
     if u"." in timestamp_str:
         fmt = u"%Y-%m-%dT%H:%M:%S.%fZ"
+        
+        # maximum supported precision by Datetime is microsecond
+        timestamp_parts = timestamp_str.split(u".")
+        if len(timestamp_parts[1]) > 7 and timestamp_parts[1].endswith(u"Z"):
+            timestamp_parts[1] = timestamp_parts[1][:6] + timestamp_parts[1][-1:]
+            timestamp_str = u".".join(timestamp_parts)
     else:
         fmt = u"%Y-%m-%dT%H:%M:%SZ"
 

--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -478,7 +478,6 @@ def _str_to_datetime(timestamp_str, ignore_case=False):
     # Can't create a pattern with an optional part... so use two patterns
     if u"." in timestamp_str:
         fmt = u"%Y-%m-%dT%H:%M:%S.%fZ"
-        
         # maximum supported precision by Datetime is microsecond
         timestamp_parts = timestamp_str.split(u".")
         if len(timestamp_parts[1]) > 7 and timestamp_parts[1].endswith(u"Z"):

--- a/stix2matcher/test/test_timestamps.py
+++ b/stix2matcher/test/test_timestamps.py
@@ -14,6 +14,7 @@ _observations = [
                 "type": "event",
                 "good_ts": u"2010-05-21T13:21:43Z",
                 "good_ts_frac": u"2010-05-21T13:21:43.1234Z",
+                "good_ts_frac_nano": u"2010-05-21T13:21:43.123456789Z",
                 "bad_ts": [
                     u"2010-05-21T13:21:43",
                     u"2010-05-21T13:21:43z",
@@ -34,6 +35,7 @@ _observations = [
     "[event:good_ts > t'1974-11-05T05:31:11Z']",
     "[event:good_ts < t'3012-08-17T17:43:55Z']",
     "[event:good_ts_frac = t'2010-05-21T13:21:43.1234Z']",
+    "[event:good_ts_frac_nano = t'2010-05-21T13:21:43.123456789Z']",
     "[event:good_ts IN (t'1953-11-26T14:25:33Z', t'2010-05-21T13:21:43Z', t'2000-06-17T17:25:51.44Z')]",
     "[event:good_ts NOT IN (t'1953-11-26T14:25:33Z', t'1985-07-25T20:27:52Z', t'2000-06-17T17:25:51.44Z')]"
 ])
@@ -48,6 +50,7 @@ def test_ts_match(pattern):
     "[event:good_ts <= t'1974-11-05T05:31:11Z']",
     "[event:good_ts >= t'3012-08-17T17:43:55Z']",
     "[event:good_ts_frac != t'2010-05-21T13:21:43.1234Z']",
+    "[event:good_ts_frac_nano != t'2010-05-21T13:21:43.123456789Z']",
     "[event:good_ts NOT IN (t'1953-11-26T14:25:33Z', t'2010-05-21T13:21:43Z', t'2000-06-17T17:25:51.44Z')]",
     "[event:good_ts IN (t'1953-11-26T14:25:33Z', t'1985-07-25T20:27:52Z', t'2000-06-17T17:25:51.44Z')]"
 ])


### PR DESCRIPTION
strptime raises ValueError in case of nanoseconds precising (i.e. "2021-03-04T12:00:25.639380322Z"),
Maximum supported precision by Datetime is microsecond. 
The proposed change doesn't preserve the nanoseconds it just chops off after 6 decimal places, but it at least won't break parsing in case of more than 6 decimal places.