### PR TITLE
Performance boost

### DIFF
--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -988,10 +988,6 @@ class MatchListener(STIXPatternListener):
             callbacks and stack activity to stdout.  This can provide useful
             information about what the matcher is doing.
         """
-
-        # This "unpacks" the SDOs, creating repeated observations.  This
-        # doesn't make copies of observations; the same dict is repeated
-        # several times in the list.  Same goes for the timestamps.
         self.__observations = []
         self.__time_intervals = []  # 2-tuples of first,last timestamps
         for sdo in observed_data_sdos:
@@ -1002,14 +998,10 @@ class MatchListener(STIXPatternListener):
                                        "(must be >= 1): {}".format(
                                         number_observed))
 
-            self.__observations.extend(
-                itertools.repeat(sdo, number_observed)
-            )
-            self.__time_intervals.extend(
-                itertools.repeat((_str_to_datetime(sdo["first_observed"]),
-                                  _str_to_datetime(sdo["last_observed"])),
-                                 number_observed)
-            )
+            self.__observations.append(sdo)
+
+            self.__time_intervals.append((_str_to_datetime(sdo["first_observed"]),
+                                          _str_to_datetime(sdo["last_observed"])))
 
         self.__verbose = verbose
         # Holds intermediate results
@@ -1069,8 +1061,7 @@ class MatchListener(STIXPatternListener):
         bindings are returned.
 
         The returned bindings will be a generator of tuples of ints.  These ints
-        correspond to observations, not SDOs.  There is a difference when any
-        SDOs have number_observed > 1.  `None` can also occur in any tuple.
+        correspond to SDOs.  `None` can also occur in any tuple.
         This corresponds to a portion of the pattern to which no observation
         was bound (because a binding was not necessary).  To get the actual
         SDOs from a binding, see get_sdos_from_binding().  If the pattern
@@ -1084,7 +1075,8 @@ class MatchListener(STIXPatternListener):
         # could be anything... so don't call this function in that situation!
         if self.__compute_stack:
             for binding in self.__compute_stack[0]:
-                yield binding
+                # convert back from complex instance_id to obs_index
+                yield tuple(map(self.get_obs_index_filtered, binding))
         return
 
     def get_sdos_from_binding(self, binding):
@@ -1101,6 +1093,47 @@ class MatchListener(STIXPatternListener):
                 sdos.append(self.__observations[obs_idx])
 
         return sdos
+
+    @staticmethod
+    def get_obs_index(instance_id):
+        """
+        Calculates the observable index from instance index.
+        :param instance_id: an instance id representation, created by
+        create_instance_index(obs_idx, inst_idx)
+        :return: int: the original observation index
+        """
+        if instance_id is None:
+            return None
+        return instance_id[0]
+
+    @staticmethod
+    def get_obs_index_filtered(instance_id):
+        """
+        Same as `get_obs_index(instance_index)`, but returns `None`
+        if instance_index is not 0. Useful with a filter predicate
+        to make sure every observable is included only once.
+        :param instance_id: an instance id representation, created by
+        create_instance_index(obs_idx, inst_idx)
+        :return: int: the original observation index for the first
+        instance of each observable and `None` for the rest.
+        """
+        if instance_id is None:
+            return None
+        return instance_id[0] if instance_id[1] == 0 else None
+
+    @staticmethod
+    def create_instance_id(obs_idx: int, inst_idx: int):
+        """
+        Creates instance index from an observable index and instance id.
+        This complex index is used after the initial filtering of the
+        observables to represent the "real" appearance if the objects
+        for REPEATS, FOLLOWEDBY and other high level operators.
+        :param obs_idx: index of the observed_data object
+        :param inst_idx: id of the instance, based on the `number_occured`
+        field.
+        :returns a Tuple, representing the complex instance id
+        """
+        return obs_idx, inst_idx
 
     def exitObservationExpressions(self, ctx):
         """
@@ -1201,16 +1234,18 @@ class MatchListener(STIXPatternListener):
 
     def __latest_first_timestamp(self, binding):
         return max(
-            self.__time_intervals[obs_id][0]
-            for obs_id in binding
-            if obs_id is not None
+            # time interval is based on the original obs_index
+            self.__time_intervals[self.get_obs_index(inst_id)][0]
+            for inst_id in binding
+            if inst_id is not None
         )
 
     def __earliest_last_timestamp(self, binding):
         return min(
-            self.__time_intervals[obs_id][1]
-            for obs_id in binding
-            if obs_id is not None
+            # time interval is based on the original obs_index
+            self.__time_intervals[self.get_obs_index(inst_id)][1]
+            for inst_id in binding
+            if inst_id is not None
         )
 
     def exitObservationExpressionOr(self, ctx):
@@ -1379,7 +1414,11 @@ class MatchListener(STIXPatternListener):
 
         debug_label = u"exitObservationExpression (simple)"
         obs_ids = self.__pop(debug_label)
-        obs_id_tuples = ((obs_id,) for obs_id in obs_ids.keys())
+        # "Unpack" the instances of observables based on `number_observed`
+        # field by creating complex instance_id
+        obs_id_tuples = ((self.create_instance_id(obs_id, i),) for obs_id in obs_ids.keys()
+                         for i in range(0, self.__observations[obs_id]['number_observed']))
+
         self.__push(obs_id_tuples, debug_label)
 
     # Don't need to do anything for exitObservationExpressionCompound
@@ -1441,9 +1480,10 @@ class MatchListener(STIXPatternListener):
         def check_within(binding):
             return _timestamp_intervals_within(
                 [
-                    self.__time_intervals[obs_id]
-                    for obs_id in binding
-                    if obs_id is not None
+                    # time interval is based on the original obs_index
+                    self.__time_intervals[self.get_obs_index(inst_id)]
+                    for inst_id in binding
+                    if inst_id is not None
                 ],
                 duration
             )
@@ -1475,7 +1515,10 @@ class MatchListener(STIXPatternListener):
 
         def check_overlap(binding):
             return all(
-                    _overlap(start_time, stop_time, *self.__time_intervals[obs_id])
+                    _overlap(start_time, stop_time, *self.__time_intervals[
+                        # time interval is based on the original obs_index
+                        self.get_obs_index(obs_id)
+                    ])
                     in (_OVERLAP, _OVERLAP_TOUCH_OUTER)
                     for obs_id in binding if obs_id is not None
                 )

--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -1367,7 +1367,7 @@ class MatchListener(STIXPatternListener):
 
     def exitObservationExpressionSimple(self, ctx):
         """
-        Consumes a the results of the inner comparison expression.  See
+        Consumes the results of the inner comparison expression.  See
         exitComparisonExpression().
         Produces: a generator of 1-tuples of the IDs.  At this stage, the root
         Cyber Observable object IDs are no longer needed, and are dropped.
@@ -1386,8 +1386,8 @@ class MatchListener(STIXPatternListener):
 
     def exitObservationExpressionRepeated(self, ctx):
         """
-        Consumes a genrator of bindings for the qualified observation expression.
-        Produces a genrator of bindings which account for the repetition. The
+        Consumes a generator of bindings for the qualified observation expression.
+        Produces a generator of bindings which account for the repetition. The
         length of each new binding is equal to the length of the old bindings
         times the repeat count.
         """

--- a/stix2matcher/test/test_complex.py
+++ b/stix2matcher/test/test_complex.py
@@ -104,7 +104,6 @@ def test_combinatorial_explosion_match(pattern):
     assert match(pattern, _observations_combinatorial_explosion)
 
 
-@pytest.mark.skip(reason="Too slow with the current implementation")
 @pytest.mark.parametrize("pattern", [
     "[person:age < 20] REPEATS 10 TIMES WITHIN 8 SECONDS",
 ])


### PR DESCRIPTION
Addresses issue #67 .

The main idea in this change is to push the "unpacking" of instances to a later stage. It will happen after the initial filtering of the observables, but before the high level operators, like `REPEATS` or `FOLLOWEDBY`.

Based on experiments on real data, created by `stix-shifter` of low level monitoring events, such as EDRs or Sysmon, the boost in performance can be enormous. As an example, there are 15,754 observables generated out of 100 original observables. In another example, there are 189,023 instances generated out of 300 original observables.

When comparing the two above example with a version without instances duplication, the timing is as follows:

Improvement | Time measured for 100 observed_data | % of improvement | Time measured for 300 observed_data | % of improvement
-- | -- | -- | -- | --
basic | 0:04:59.641 |   | 1:00:40.532 |  
events deduplication | 0:00:06.043 | 97.98% | 0:00:15.945 | 99.56%

For the above 2 examples, the performance boost will be `x50` and `x200` respectively.