### PR TITLE
Stringify base64 decoded bytes for LIKE operator

### DIFF
--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -295,7 +295,7 @@ def _process_prop_suffix(prop_name, value):
         value = binascii.a2b_hex(value)
     elif prop_name.endswith(u"_bin"):
         # binary type, expressed as base64
-        value = base64.standard_b64decode(value).decode("ascii")
+        value = base64.standard_b64decode(value).decode("utf8")
 
     return value
 

--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -295,7 +295,7 @@ def _process_prop_suffix(prop_name, value):
         value = binascii.a2b_hex(value)
     elif prop_name.endswith(u"_bin"):
         # binary type, expressed as base64
-        value = base64.standard_b64decode(value).decode("utf8")
+        value = base64.standard_b64decode(value)
 
     return value
 
@@ -1938,8 +1938,12 @@ class MatchListener(STIXPatternListener):
         regex = _like_to_regex(operand_str)
         # compile and cache this to improve performance
         compiled_re = re.compile(regex)
+        is_binary_convertible = all(ord(c) < 256 for c in regex)
 
         def like_pred(value):
+            if isinstance(value, six.binary_type) and is_binary_convertible:
+                value = value.decode('utf8')
+
             # non-strings can't match
             if isinstance(value, six.text_type):
                 value = unicodedata.normalize("NFC", value)

--- a/stix2matcher/matcher.py
+++ b/stix2matcher/matcher.py
@@ -295,7 +295,7 @@ def _process_prop_suffix(prop_name, value):
         value = binascii.a2b_hex(value)
     elif prop_name.endswith(u"_bin"):
         # binary type, expressed as base64
-        value = base64.standard_b64decode(value)
+        value = base64.standard_b64decode(value).decode("ascii")
 
     return value
 

--- a/stix2matcher/test/test_binary.py
+++ b/stix2matcher/test/test_binary.py
@@ -46,6 +46,11 @@ _observations = [
     "[binary_test:name_bin NOT MATCHES '\\\\x62o[b\\\\x01]']",
     u"[binary_test:name_bin NOT MATCHES '\u0103lice']",
 
+    "[binary_test:name_bin LIKE '%alice%']",
+    "[binary_test:name_bin LIKE 'alice']",
+    "[binary_test:name_bin NOT LIKE '%\u0103lice%']",
+    "[binary_test:name_bin NOT LIKE '%aardvark%']",
+
     # some nonprintable binary data tests too.
     "[binary_test:bin_hex = h'01020304']",
     "[binary_test:bin_hex = b'AQIDBA==']",
@@ -64,6 +69,7 @@ def test_binary_match(pattern):
     u"[binary_test:name_bin = '\u0103lice']",
     u"[binary_test:name_bin > '\u0103lice']",
     u"[binary_test:name_bin < '\u0103lice']",
+    u"[binary_test:name_bin LIKE '\u0103lice']",
     u"[binary_test:name_bin MATCHES '\u0103lice']",
     u"[binary_test:name_hex = '\u0103lice']",
     u"[binary_test:name_hex > '\u0103lice']",


### PR DESCRIPTION
Return base64 decoded value as string instead of bytes. Is used to search _bin property values with human readable queries. 